### PR TITLE
fix(#3): Fallback to 'master' if 'main' diff retrieval fails

### DIFF
--- a/git/realGit.go
+++ b/git/realGit.go
@@ -26,7 +26,18 @@ func (r *RealGit) GetDiff(baseBranch string) (string, error) {
     cmd.Stdout = &out
     err := cmd.Run()
     if err != nil {
-        return "", err
+        // Attempt to get diff for 'master' if 'main' fails
+        if baseBranch == "main" {
+            cmd = exec.Command("git", "diff", "master")
+            out.Reset()
+            cmd.Stdout = &out
+            err = cmd.Run()
+            if err != nil {
+                return "", err
+            }
+        } else {
+            return "", err
+        }
     }
     diff := out.String()
     return diff, nil


### PR DESCRIPTION
This pull request enhances the `GetDiff` function in `realGit.go` to improve robustness by attempting to retrieve a diff from the 'master' branch if the 'main' branch is unavailable. This change ensures compatibility with repositories that may use 'master' as the default branch. Closes #3.