### PR TITLE
feat(#5): Add 'heal' command to amend commit messages with issue number

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,10 @@ import (
     "gopkg.in/yaml.v2"
     "io/ioutil"
     "os"
+    "os/exec"
+    "bytes"
+    "strings"
+    "regexp"
 )
 
 func main() {
@@ -21,6 +25,8 @@ func main() {
         handlePR()
     case "help":
         handleHelp()
+    case "heal":
+        handleHeal()
     default:
         fmt.Printf("Error: Unknown command '%s'. Use 'aidy help' for usage.\n", command)
         os.Exit(1)
@@ -83,4 +89,69 @@ func handleHelp() {
     fmt.Println("Usage:")
     fmt.Println("  aidy pr   - Generate a pull request using AI-generated title and body.")
     fmt.Println("  aidy help - Show this help message.")
+}
+
+func handleHeal() {
+    // Read API key from configuration file
+    homeDir, err := os.UserHomeDir()
+    if err != nil {
+        log.Fatalf("Error getting home directory: %v", err)
+    }
+    configPath := fmt.Sprintf("%s/.aidy.conf.yml", homeDir)
+    configData, err := ioutil.ReadFile(configPath)
+    if err != nil {
+        log.Fatalf("Error reading config file: %v", err)
+    }
+
+    var config struct {
+        OpenAIAPIKey string `yaml:"openai-api-key"`
+    }
+
+    err = yaml.Unmarshal(configData, &config)
+    if err != nil {
+        log.Fatalf("Error parsing config file: %v", err)
+    }
+
+    apiKey := config.OpenAIAPIKey
+    if apiKey == "" {
+        log.Fatalf("OpenAI API key not found in config file")
+    }
+    gitService := &git.RealGit{}
+
+    branchName, err := gitService.GetBranchName()
+    if err != nil {
+        log.Fatalf("Error getting branch name: %v", err)
+    }
+
+    // Extract issue number from branch name
+    issueNumber := extractIssueNumber(branchName)
+
+    // Get the current commit message
+    cmd := exec.Command("git", "log", "-1", "--pretty=%B")
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    err = cmd.Run()
+    if err != nil {
+        log.Fatalf("Error getting current commit message: %v", err)
+    }
+    commitMessage := out.String()
+    re := regexp.MustCompile(`#\d+`)
+    newCommitMessage := re.ReplaceAllString(commitMessage, fmt.Sprintf("#%s", issueNumber))
+    fmt.Printf("Executing command: 'git commit --amend -m \"%s\"''", newCommitMessage)
+    cmd = exec.Command("git", "commit", "--amend", "-m", newCommitMessage)
+    err = cmd.Run()
+    if err != nil {
+        log.Fatalf("Error amending commit message: %v", err)
+    }
+    fmt.Println("Commit message healed successfully.")
+}
+
+
+func extractIssueNumber(branchName string) string {
+    // Assuming the branch name format is "<issue-number>_<description>"
+    parts := strings.Split(branchName, "_")
+    if len(parts) > 0 {
+        return parts[0]
+    }
+    return "unknown"
 }


### PR DESCRIPTION
This pull request introduces a new command, `heal` , to the application. The `heal` command amends the latest commit message by replacing any issue number references with the correct issue number extracted from the branch name. This feature enhances commit message consistency and accuracy by ensuring the correct issue number is referenced. 

Closes #5.