### PR TITLE
feat(#11): Implement `Executor` interface with mock and real executors

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1,0 +1,5 @@
+package executor
+
+type Executor interface {
+    RunCommand(name string, args ...string) (string, error)
+}

--- a/executor/mockexecutor.go
+++ b/executor/mockexecutor.go
@@ -1,0 +1,10 @@
+package executor
+
+type MockExecutor struct {
+    Output string
+    Err    error
+}
+
+func (m *MockExecutor) RunCommand(name string, args ...string) (string, error) {
+    return m.Output, m.Err
+}

--- a/executor/mockexecutor_test.go
+++ b/executor/mockexecutor_test.go
@@ -1,0 +1,36 @@
+package executor
+
+import (
+    "fmt"
+    "testing"
+)
+
+func TestMockExecutor_RunCommand(t *testing.T) {
+    mock := &MockExecutor{
+        Output: "mock output",
+        Err:    nil,
+    }
+
+    output, err := mock.RunCommand("any-command")
+    if err != nil {
+        t.Fatalf("Expected no error, got %v", err)
+    }
+    if output != "mock output" {
+        t.Fatalf("Expected 'mock output', got '%s'", output)
+    }
+}
+
+func TestMockExecutor_RunCommandWithError(t *testing.T) {
+    mock := &MockExecutor{
+        Output: "",
+        Err:    fmt.Errorf("mock error"),
+    }
+
+    _, err := mock.RunCommand("any-command")
+    if err == nil {
+        t.Fatal("Expected error, got none")
+    }
+    if err.Error() != "mock error" {
+        t.Fatalf("Expected 'mock error', got '%v'", err)
+    }
+}

--- a/executor/realexecutor.go
+++ b/executor/realexecutor.go
@@ -1,0 +1,19 @@
+package executor
+
+import (
+    "bytes"
+    "os/exec"
+)
+
+type RealExecutor struct{}
+
+func (r *RealExecutor) RunCommand(name string, args ...string) (string, error) {
+    cmd := exec.Command(name, args...)
+    var out bytes.Buffer
+    cmd.Stdout = &out
+    err := cmd.Run()
+    if err != nil {
+        return "", err
+    }
+    return out.String(), nil
+}

--- a/executor/realexecutor_test.go
+++ b/executor/realexecutor_test.go
@@ -1,0 +1,24 @@
+package executor
+
+import (
+    "strings"
+    "testing"
+)
+
+func TestRealExecutor_RunCommand(t *testing.T) {
+    executor := &RealExecutor{}
+
+    // Test the echo command
+    output, err := executor.RunCommand("echo", "Hello, World!")
+    if err != nil {
+        t.Fatalf("Expected no error, got %v", err)
+    }
+
+    // Trim the output to remove any trailing newline characters
+    output = strings.TrimSpace(output)
+
+    expectedOutput := "Hello, World!"
+    if output != expectedOutput {
+        t.Fatalf("Expected '%s', got '%s'", expectedOutput, output)
+    }
+}

--- a/main_test.go
+++ b/main_test.go
@@ -9,7 +9,6 @@ import (
     "github.com/volodya-lombrozo/aidy/ai"
 )
 
-
 func TestHandleIssue(t *testing.T) {
     mockAI := &ai.MockAI{}
     userInput := "test input"
@@ -27,7 +26,6 @@ func TestHandleIssue(t *testing.T) {
         t.Errorf("Unexpected output:\n%s", output)
     }
 }
-
 
 func TestHandleHelp(t *testing.T) {
     old := os.Stdout


### PR DESCRIPTION
This pull request introduces an `Executor` interface along with its `MockExecutor` and `RealExecutor` implementations. The `MockExecutor` is designed for testing purposes, while the `RealExecutor` executes actual system commands. Unit tests for both executors are included to ensure their correct functionality. 

Related to #11.