### PR TITLE
ci(#11): Add GitHub Actions for testing and code coverage

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,23 @@
+name: Test and coverage
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+      - name: Run coverage
+        run: go test -race -coverprofile=coverage.out -covermode=atomic
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Test 
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+      - name: Run all tests
+        run: go test ./... 
+      

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .aider*
 aidy
 .idea
+coverage.out

--- a/git/realgit_test.go
+++ b/git/realgit_test.go
@@ -12,11 +12,20 @@ func setupTestRepo(t *testing.T) (string, func()) {
     if err != nil {                                                                                                                                                                                  
         t.Fatalf("Failed to create temp dir: %v", err)                                                                                                                                               
     }                                                                                                                                                                                                
-    cmd := exec.Command("git", "init")                                                                                                                                                               
+    cmd := exec.Command("git", "init", "--initial-branch", "main")                                                                                                                                                               
     cmd.Dir = tempDir                                                                                                                                                                                
     if err := cmd.Run(); err != nil {                                                                                                                                                                
         t.Fatalf("Failed to initialize git repo: %v", err)                                                                                                                                           
     } 
+
+    cmd = exec.Command("git", "config", "user.name", "Test User")
+    cmd.Dir = tempDir
+    _ = cmd.Run()
+
+    cmd = exec.Command("git", "config", "user.email", "test@example.com")
+    cmd.Dir = tempDir
+    _ = cmd.Run()
+
     cmd = exec.Command("git", "commit", "-m", "initial commit", "--allow-empty")                                                                                                                                              
     cmd.Dir = tempDir                                                                                                                                                                                
     if err := cmd.Run(); err != nil {                                                                                                                                                                

--- a/main.go
+++ b/main.go
@@ -7,11 +7,7 @@ import (
     "github.com/volodya-lombrozo/aidy/git"
     "github.com/volodya-lombrozo/aidy/config"
     "github.com/volodya-lombrozo/aidy/executor"
-    "gopkg.in/yaml.v2"
-    "io/ioutil"
     "os"
-    "os/exec"
-    "bytes"
     "strings"
     "regexp"
 )


### PR DESCRIPTION
This pull request introduces GitHub Actions workflows for continuous integration and code coverage reporting. It adds two workflows: one triggered on pushes to the `main` branch for running tests and uploading coverage data, and another for pull requests to ensure code quality before merging. Additionally, it updates the `.gitignore` file to exclude coverage reports. 

Related to #11.