### PR TITLE
ci(#11): Update `go test` command and add Codecov badge to README

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           go-version: '1.24'
       - name: Run coverage
-        run: go test -race -coverprofile=coverage.out -covermode=atomic
+        run: go test -race -coverprofile=coverage.out -coverpkg=./... -covermode=atomic ./...
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Aidy
+[![codecov](https://codecov.io/gh/volodya-lombrozo/jtcop/branch/main/graph/badge.svg)](https://codecov.io/gh/volodya-lombrozo/aidy)
 
 Aidy is a command-line tool that generates GitHub pull request commands with AI-generated titles and body messages.
 


### PR DESCRIPTION
This pull request enhances the Go test coverage command to include all packages and adds a Codecov badge to the `README.md` for better visibility of code coverage status. Closes #11.