### PR TITLE
feat(#19): Add `RunCommandInDir` method to `Executor` interface

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -2,4 +2,6 @@ package executor
 
 type Executor interface {
 	RunCommand(name string, args ...string) (string, error)
+
+	RunCommandInDir(dir string, name string, args ...string) (string, error)
 }

--- a/executor/mockexecutor.go
+++ b/executor/mockexecutor.go
@@ -13,3 +13,9 @@ func (m *MockExecutor) RunCommand(name string, args ...string) (string, error) {
 	m.Commands = append(m.Commands, command)
 	return m.Output, m.Err
 }
+
+func (m *MockExecutor) RunCommandInDir(dir string, name string, args ...string) (string, error) {
+	command := "cd " + dir + " && " + name + " " + strings.Join(args, " ")
+	m.Commands = append(m.Commands, command)
+	return m.Output, m.Err
+}

--- a/executor/realexecutor.go
+++ b/executor/realexecutor.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"bytes"
+	"fmt"
 	"log"
 	"os/exec"
 	"strings"
@@ -17,6 +18,21 @@ func (r *RealExecutor) RunCommand(name string, args ...string) (string, error) {
 	err := cmd.Run()
 	if err != nil {
 		return "", err
+	}
+	return out.String(), nil
+}
+
+func (r *RealExecutor) RunCommandInDir(dir string, name string, args ...string) (string, error) {
+	log.Printf("Executing command in directory %s: %s %s", dir, name, strings.Join(args, " "))
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("error: %v; stderr: %s", err, strings.TrimSpace(stderr.String()))
 	}
 	return out.String(), nil
 }

--- a/executor/realexecutor_test.go
+++ b/executor/realexecutor_test.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"os"
 	"strings"
 	"testing"
 )
@@ -18,6 +19,31 @@ func TestRealExecutor_RunCommand(t *testing.T) {
 	output = strings.TrimSpace(output)
 
 	expectedOutput := "Hello, World!"
+	if output != expectedOutput {
+		t.Fatalf("Expected '%s', got '%s'", expectedOutput, output)
+	}
+}
+
+func TestRealExecutor_RunCommandInDir(t *testing.T) {
+	// Create a temporary directory
+	tempDir, err := os.MkdirTemp("", "execdirtest")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			t.Fatalf("Error removing temp directory: %v", err)
+		}
+	}()
+
+	executor := &RealExecutor{}
+	output, err := executor.RunCommandInDir(tempDir, "echo", "Hello, Directory!")
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	output = strings.TrimSpace(output)
+	expectedOutput := "Hello, Directory!"
 	if output != expectedOutput {
 		t.Fatalf("Expected '%s', got '%s'", expectedOutput, output)
 	}

--- a/git/realgit.go
+++ b/git/realgit.go
@@ -1,20 +1,20 @@
 package git
 
 import (
-	"bytes"
 	"fmt"
+	"github.com/volodya-lombrozo/aidy/executor"
 	"log"
 	"os"
-	"os/exec"
 	"strings"
 )
 
 type RealGit struct {
-	dir string
+	dir   string
+	shell executor.Executor
 }
 
 // NewRealGit creates a new RealGit instance. If no directory is provided, it uses the current working directory.
-func NewRealGit(dir ...string) *RealGit {
+func NewRealGit(shell executor.Executor, dir ...string) *RealGit {
 	var directory string
 	if len(dir) > 0 && dir[0] != "" {
 		directory = dir[0]
@@ -25,35 +25,24 @@ func NewRealGit(dir ...string) *RealGit {
 			panic(fmt.Errorf("failed to get current working directory: %w", err))
 		}
 	}
-	return &RealGit{dir: directory}
+	return &RealGit{dir: directory, shell: shell}
 }
 
 func (r *RealGit) GetBranchName() (string, error) {
-	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
-	var out, stderr bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &stderr
-	cmd.Dir = r.dir
-	err := cmd.Run()
+	branchName, err := r.shell.RunCommandInDir(r.dir, "git", "rev-parse", "--abbrev-ref", "HEAD")
 	if err != nil {
-		return "", fmt.Errorf("error running git rev-parse: %v; stderr: %s", err, strings.TrimSpace(stderr.String()))
+		return "", err
 	}
-	branchName := strings.TrimSpace(out.String())
+	branchName = strings.TrimSpace(branchName)
 	return branchName, nil
 }
 
 func (r *RealGit) GetBaseBranchName() (string, error) {
 	log.Printf("Executing command to check base branch in directory: %s", r.dir)
 	// Check if 'main' branch exists
-	cmd := exec.Command("git", "show-ref", "--verify", "--quiet", "refs/heads/main")
-	cmd.Dir = r.dir
-	errMain := cmd.Run()
-
+	_, errMain := r.shell.RunCommandInDir(r.dir, "git", "show-ref", "--verify", "--quiet", "refs/heads/main")
 	// Check if 'master' branch exists
-	cmd = exec.Command("git", "show-ref", "--verify", "--quiet", "refs/heads/master")
-	cmd.Dir = r.dir
-	errMaster := cmd.Run()
-
+	_, errMaster := r.shell.RunCommandInDir(r.dir, "git", "show-ref", "--verify", "--quiet", "refs/heads/master")
 	if errMain == nil && errMaster == nil {
 		return "", fmt.Errorf("both 'main' and 'master' branches exist")
 	} else if errMain == nil {
@@ -66,34 +55,25 @@ func (r *RealGit) GetBaseBranchName() (string, error) {
 }
 
 func (r *RealGit) GetDiff() (string, error) {
-	// Determine the base branch name
 	baseBranch, err := r.GetBaseBranchName()
 	if err != nil {
 		return "", fmt.Errorf("error determining base branch: %v", err)
 	}
-	cmd := exec.Command("git", "diff", baseBranch)
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Dir = r.dir
-	err = cmd.Run()
-	if err != nil {
+	out, diffErr := r.shell.RunCommandInDir(r.dir, "git", "diff", baseBranch)
+	if diffErr != nil {
 		return "", err
 	} else {
-		diff := out.String()
+		diff := out
 		return diff, nil
 	}
 }
 
 func (r *RealGit) GetCurrentCommitMessage() (string, error) {
-	cmd := exec.Command("git", "log", "-1", "--pretty=%B")
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Dir = r.dir
-	err := cmd.Run()
+	out, err := r.shell.RunCommandInDir(r.dir, "git", "log", "-1", "--pretty=%B")
 	if err != nil {
 		return "", err
 	}
-	commitMessage := out.String()
+	commitMessage := out
 	commitMessage = strings.TrimSpace(commitMessage)
 	return commitMessage, nil
 }

--- a/git/realgit_test.go
+++ b/git/realgit_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"github.com/volodya-lombrozo/aidy/executor"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -51,7 +52,7 @@ func setupTestRepo(t *testing.T) (string, func()) {
 func TestRealGetBranchName(t *testing.T) {
 	dir, cleanup := setupTestRepo(t)
 	defer cleanup()
-	gitService := NewRealGit(dir)
+	gitService := NewRealGit(&executor.RealExecutor{}, dir)
 	branchName, err := gitService.GetBranchName()
 	if err != nil {
 		t.Fatalf("Error getting branch name: %v", err)
@@ -64,7 +65,7 @@ func TestRealGetBranchName(t *testing.T) {
 func TestRealGetBaseBranchName(t *testing.T) {
 	repoDir, cleanup := setupTestRepo(t)
 	defer cleanup()
-	gitService := NewRealGit(repoDir)
+	gitService := NewRealGit(&executor.RealExecutor{}, repoDir)
 	baseBranch, err := gitService.GetBaseBranchName()
 	if err != nil {
 		t.Fatalf("Error getting base branch name: %v", err)
@@ -94,7 +95,7 @@ func TestRealGetDiff(t *testing.T) {
 	if err := os.WriteFile(filePath, []byte("Hello, Git!"), 0644); err != nil {
 		t.Fatalf("Error writing to file: %v", err)
 	}
-	gitService := NewRealGit(repoDir)
+	gitService := NewRealGit(&executor.RealExecutor{}, repoDir)
 	diff, err := gitService.GetDiff()
 	if err != nil {
 		t.Fatalf("Error getting diff: %v", err)
@@ -123,7 +124,7 @@ func TestRealGetCurrentCommitMessage(t *testing.T) {
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("Error running command: %v", err)
 	}
-	gitService := NewRealGit(repoDir)
+	gitService := NewRealGit(&executor.RealExecutor{}, repoDir)
 	message, err := gitService.GetCurrentCommitMessage()
 	if err != nil {
 		t.Fatalf("Error getting current commit message: %v", err)

--- a/main.go
+++ b/main.go
@@ -35,9 +35,9 @@ func main() {
 	if apiKey == "" {
 		log.Fatalf("OpenAI API key not found in config file")
 	}
-	aiService := ai.NewOpenAI(apiKey, "gpt-4o", 0.2)
-	gitService := git.NewRealGit()
 	shell := &executor.RealExecutor{}
+	aiService := ai.NewOpenAI(apiKey, "gpt-4o", 0.2)
+	gitService := git.NewRealGit(shell)
 	switch command {
 	case "help":
 		help()


### PR DESCRIPTION
This pull request introduces a new method `RunCommandInDir` to the `Executor` interface, allowing commands to be executed within a specified directory. The `RealExecutor` and `MockExecutor` implementations have been updated accordingly. Additionally, the `RealGit` struct now utilizes the `Executor` interface for executing Git commands, enhancing modularity and testability. Tests have been added to ensure the new functionality works as expected.

Closes #19