### PR TITLE
refactor(#37): Implement `logShortf` for concise logging and error handling

### DIFF
--- a/executor/realexecutor.go
+++ b/executor/realexecutor.go
@@ -9,9 +9,10 @@ import (
 )
 
 type RealExecutor struct{}
+const maxLogLength = 120
 
 func (r *RealExecutor) RunCommand(name string, args ...string) (string, error) {
-	log.Printf("Executing command: %s %s", name, strings.Join(args, " "))
+	logShortf("Execute: \"%s %s\"", name, strings.Join(args, " "))
 	cmd := exec.Command(name, args...)
 	var out bytes.Buffer
 	cmd.Stdout = &out
@@ -23,7 +24,7 @@ func (r *RealExecutor) RunCommand(name string, args ...string) (string, error) {
 }
 
 func (r *RealExecutor) RunCommandInDir(dir string, name string, args ...string) (string, error) {
-	log.Printf("Executing command in directory %s: %s %s", dir, name, strings.Join(args, " "))
+	logShortf("Execute (%s): \"%s %s\"", dir, name, strings.Join(args, " "))
 	cmd := exec.Command(name, args...)
 	cmd.Dir = dir
 	var out bytes.Buffer
@@ -35,4 +36,16 @@ func (r *RealExecutor) RunCommandInDir(dir string, name string, args ...string) 
 		return "", fmt.Errorf("error: %v; stderr: %s", err, strings.TrimSpace(stderr.String()))
 	}
 	return out.String(), nil
+}
+
+func logShortf(format string, args ...interface{}) {
+	msg := format
+	if len(args) > 0 {
+		msg = fmt.Sprintf(format, args...)
+	}
+	if len(msg) > maxLogLength {
+		msg = msg[:maxLogLength] + "…"
+	}
+	msg = strings.ReplaceAll(msg, "\n", " ")
+	log.Print(msg)
 }

--- a/git/realgit.go
+++ b/git/realgit.go
@@ -3,7 +3,6 @@ package git
 import (
 	"fmt"
 	"github.com/volodya-lombrozo/aidy/executor"
-	"log"
 	"os"
 	"strings"
 )
@@ -38,7 +37,6 @@ func (r *RealGit) GetBranchName() (string, error) {
 }
 
 func (r *RealGit) GetBaseBranchName() (string, error) {
-	log.Printf("Executing command to check base branch in directory: %s", r.dir)
 	// Check if 'main' branch exists
 	_, errMain := r.shell.RunCommandInDir(r.dir, "git", "show-ref", "--verify", "--quiet", "refs/heads/main")
 	// Check if 'master' branch exists

--- a/main.go
+++ b/main.go
@@ -14,8 +14,7 @@ import (
 
 func main() {
 	if len(os.Args) < 2 {
-		fmt.Println("Error: No command provided. Use 'aidy help' for usage.")
-		os.Exit(1)
+		log.Fatal("Error: No command provided. Use 'aidy help' for usage.")
 	}
 	command := os.Args[1]
 
@@ -56,8 +55,7 @@ func main() {
 		userInput := os.Args[2]
 		issue(userInput, aiService)
 	default:
-		fmt.Printf("Error: Unknown command '%s'. Use 'aidy help' for usage.\n", command)
-		os.Exit(1)
+		log.Fatalf("Error: Unknown command '%s'. Use 'aidy help' for usage.\n", command)
 	}
 }
 
@@ -79,7 +77,7 @@ func issue(userInput string, aiService ai.AI) {
 	if err != nil {
 		log.Fatalf("Error generating body: %v", err)
 	}
-	fmt.Printf("Generated Issue Command:\n%s\n", escapeBackticks(fmt.Sprintf("gh issue create --title \"%s\" --body \"%s\"", title, body)))
+	fmt.Printf("\n%s\n", escapeBackticks(fmt.Sprintf("gh issue create --title \"%s\" --body \"%s\"", title, body)))
 }
 
 func squash(gitService git.Git, shell executor.Executor) {
@@ -126,7 +124,7 @@ func pull_request(gitService git.Git, aiService ai.AI) {
 	if err != nil {
 		log.Fatalf("Error generating body: %v", err)
 	}
-	fmt.Printf("Generated PR Command:\n%s\n", escapeBackticks(fmt.Sprintf("gh pr create --title \"%s\" --body \"%s\"", title, body)))
+	fmt.Printf("\n%s\n", escapeBackticks(fmt.Sprintf("gh pr create --title \"%s\" --body \"%s\"", title, body)))
 }
 
 func heal(gitService git.Git, shell executor.Executor) {
@@ -141,12 +139,10 @@ func heal(gitService git.Git, shell executor.Executor) {
 	}
 	re := regexp.MustCompile(`#\d+`)
 	newCommitMessage := re.ReplaceAllString(commitMessage, fmt.Sprintf("#%s", issueNumber))
-	fmt.Printf("Executing command: %s\n", escapeBackticks(fmt.Sprintf("git commit --amend -m \"%s\"", newCommitMessage)))
 	_, err = shell.RunCommand("git", "commit", "--amend", "-m", newCommitMessage)
 	if err != nil {
 		log.Fatalf("Error amending commit message: %v", err)
 	}
-	fmt.Println("Commit message healed successfully.")
 }
 
 func extractIssueNumber(branchName string) string {

--- a/main_test.go
+++ b/main_test.go
@@ -72,7 +72,7 @@ func TestPullRequest(t *testing.T) {
 	}
 	output := buf.String()
 
-	expected := "Generated PR Command:\ngh pr create --title \"Mock Title for 41_working_branch\" --body \"Mock Body for 41_working_branch\""
+	expected := "\ngh pr create --title \"Mock Title for 41_working_branch\" --body \"Mock Body for 41_working_branch\""
 	if strings.TrimSpace(output) != strings.TrimSpace(expected) {
 		t.Errorf("Unexpected output:\n%s", output)
 	}
@@ -114,7 +114,7 @@ func TestHandleIssue(t *testing.T) {
 		t.Fatalf("Error copying data: %v", err)
 	}
 	output := buf.String()
-	expected := "Generated Issue Command:\ngh issue create --title \"Mock Issue Title for test input\" --body \"Mock Issue Body for test input\""
+	expected := "\ngh issue create --title \"Mock Issue Title for test input\" --body \"Mock Issue Body for test input\""
 	if strings.TrimSpace(output) != strings.TrimSpace(expected) {
 		t.Errorf("Unexpected output:\n%s", output)
 	}


### PR DESCRIPTION
This pull request refactors logging in the `RealExecutor` and `main.go` by introducing a new `logShortf` function to handle log messages with a maximum length. It also replaces `fmt.Println` and `os.Exit` with `log.Fatal` for error handling in `main.go`. Additionally, it removes unnecessary log statements from `realgit.go` and updates test expectations in `main_test.go`.

Closes #37