### PR TITLE
feat(#39): Add `append` command to amend commits

### DIFF
--- a/executor/realexecutor.go
+++ b/executor/realexecutor.go
@@ -9,6 +9,7 @@ import (
 )
 
 type RealExecutor struct{}
+
 const maxLogLength = 120
 
 func (r *RealExecutor) RunCommand(name string, args ...string) (string, error) {

--- a/git/git.go
+++ b/git/git.go
@@ -5,4 +5,5 @@ type Git interface {
 	GetDiff() (string, error)
 	GetBaseBranchName() (string, error)
 	GetCurrentCommitMessage() (string, error)
+	AppendToCommit() error
 }

--- a/git/mockgit.go
+++ b/git/mockgit.go
@@ -6,6 +6,11 @@ func (m *MockGit) GetBaseBranchName() (string, error) {
 	return "main", nil
 }
 
+func (m *MockGit) AppendToCommit() error {
+	// Mock implementation, no actual git operations
+	return nil
+}
+
 func (m *MockGit) GetBranchName() (string, error) {
 	return "41_working_branch", nil
 }

--- a/git/realgit.go
+++ b/git/realgit.go
@@ -12,6 +12,18 @@ type RealGit struct {
 	shell executor.Executor
 }
 
+func (r *RealGit) AppendToCommit() error {
+	_, err := r.shell.RunCommandInDir(r.dir, "git", "add", "--all")
+	if err != nil {
+		return fmt.Errorf("error adding changes: %w", err)
+	}
+	_, err = r.shell.RunCommandInDir(r.dir, "git", "commit", "--amend", "--no-edit")
+	if err != nil {
+		return fmt.Errorf("error amending commit: %w", err)
+	}
+	return nil
+}
+
 // NewRealGit creates a new RealGit instance. If no directory is provided, it uses the current working directory.
 func NewRealGit(shell executor.Executor, dir ...string) *RealGit {
 	var directory string

--- a/git/realgit_test.go
+++ b/git/realgit_test.go
@@ -5,8 +5,34 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
+
+func TestRealGit_AppendToCommit(t *testing.T) {
+	mockExecutor := &executor.MockExecutor{}
+	gitService := NewRealGit(mockExecutor, "")
+
+	err := gitService.AppendToCommit()
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	expectedCommands := []string{
+		"git add --all",
+		"git commit --amend --no-edit",
+	}
+
+	if len(mockExecutor.Commands) != len(expectedCommands) {
+		t.Fatalf("Expected %d commands, got %d", len(expectedCommands), len(mockExecutor.Commands))
+	}
+
+	for i, cmd := range expectedCommands {
+		if !strings.Contains(mockExecutor.Commands[i], cmd) {
+			t.Errorf("Expected command '%s', got '%s'", cmd, mockExecutor.Commands[i])
+		}
+	}
+}
 
 func setupTestRepo(t *testing.T) (string, func()) {
 	tempDir, err := os.MkdirTemp("", "testrepo")

--- a/main.go
+++ b/main.go
@@ -48,6 +48,8 @@ func main() {
 		commit(gitService, shell)
 	case "sq", "squash":
 		squash(gitService, shell)
+	case "ap", "append":
+		appendToCommit(gitService)
 	case "i", "issue":
 		if len(os.Args) < 3 {
 			log.Fatalf("Error: No input provided for issue generation.")
@@ -145,6 +147,12 @@ func heal(gitService git.Git, shell executor.Executor) {
 	}
 }
 
+func appendToCommit(gitService git.Git) {
+	err := gitService.AppendToCommit()
+	if err != nil {
+		log.Fatalf("Error appending to commit: %v", err)
+	}
+}
 func extractIssueNumber(branchName string) string {
 	// Assuming the branch name format is "<issue-number>_<description>"
 	parts := strings.Split(branchName, "_")


### PR DESCRIPTION
This pull request introduces a new feature to append changes to the latest commit using the `AppendToCommit` method in the `Git` interface. It includes implementations for both `MockGit` and `RealGit`, along with a test case to ensure functionality. Additionally, a new command option ap or append is added to the main application to utilize this feature.

Closes #39