### PR TITLE
feat(#35): Add `CommitChanges` method and support `-n` flag for no AI commit

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -6,4 +6,5 @@ type Git interface {
 	GetBaseBranchName() (string, error)
 	GetCurrentCommitMessage() (string, error)
 	AppendToCommit() error
+	CommitChanges() error
 }

--- a/git/mockgit.go
+++ b/git/mockgit.go
@@ -18,6 +18,11 @@ func (m *MockGit) GetDiff() (string, error) {
 	return "mock-diff", nil
 }
 
+func (m *MockGit) CommitChanges() error {
+	// Mock implementation, no actual git operations
+	return nil
+}
+
 func (m *MockGit) GetCurrentCommitMessage() (string, error) {
 	return "feat(#42): current commit message", nil
 }

--- a/git/realgit.go
+++ b/git/realgit.go
@@ -12,6 +12,27 @@ type RealGit struct {
 	shell executor.Executor
 }
 
+func (r *RealGit) CommitChanges() error {
+	_, err := r.shell.RunCommandInDir(r.dir, "git", "add", "--all")
+	if err != nil {
+		return fmt.Errorf("error adding changes: %w", err)
+	}
+
+	changedFiles, err := r.shell.RunCommandInDir(r.dir, "git", "diff", "--name-only", "--cached")
+	if err != nil {
+		return fmt.Errorf("error getting changed files: %w", err)
+	}
+
+	commitMessage := strings.TrimSpace("Committing changes to the following files:\n" + changedFiles)
+	_, err = r.shell.RunCommandInDir(r.dir, "git", "commit", "-m", commitMessage)
+
+	if err != nil {
+		return fmt.Errorf("error committing changes: %w", err)
+	}
+
+	return nil
+}
+
 func (r *RealGit) AppendToCommit() error {
 	_, err := r.shell.RunCommandInDir(r.dir, "git", "add", "--all")
 	if err != nil {
@@ -44,7 +65,7 @@ func (r *RealGit) GetBranchName() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	branchName = strings.TrimSpace(branchName)
+	branchName = strings.TrimRight(branchName, "\r\n")
 	return branchName, nil
 }
 

--- a/git/realgit_test.go
+++ b/git/realgit_test.go
@@ -34,6 +34,38 @@ func TestRealGit_AppendToCommit(t *testing.T) {
 	}
 }
 
+func TestRealGit_CommitChanges(t *testing.T) {
+	repoDir, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	// Create a new file and stage it
+	filePath := filepath.Join(repoDir, "newfile.txt")
+	if err := os.WriteFile(filePath, []byte("New content"), 0644); err != nil {
+		t.Fatalf("Error writing to file: %v", err)
+	}
+
+	gitService := NewRealGit(&executor.RealExecutor{}, repoDir)
+
+	// Commit the changes
+	err := gitService.CommitChanges()
+	if err != nil {
+		t.Fatalf("Error committing changes: %v", err)
+	}
+
+	// Verify the commit message
+	cmd := exec.Command("git", "log", "-1", "--pretty=%B")
+	cmd.Dir = repoDir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("Error getting commit message: %v", err)
+	}
+
+	expectedMessage := "Committing changes to the following files:\nnewfile.txt\n\n"
+	if string(out) != expectedMessage {
+		t.Fatalf("Expected commit message '%s', got '%s'", expectedMessage, string(out))
+	}
+}
+
 func setupTestRepo(t *testing.T) (string, func()) {
 	tempDir, err := os.MkdirTemp("", "testrepo")
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -85,7 +85,7 @@ func TestCommit(t *testing.T) {
 		Err:    nil,
 	}
 
-	commit(mockGit, mockExecutor)
+	commit(mockGit, mockExecutor, false)
 
 	expectedCommands := []string{
 		"aider --commit --commit-prompt",


### PR DESCRIPTION
This pull request introduces a new method `CommitChanges` to the `Git` interface and its implementations, allowing for committing changes directly. The `commit` function in `main.go` is updated to support a `-n` flag, enabling commits without AI assistance. Additionally, a test for `CommitChanges` is added to ensure its functionality.

Closes #35