### PR TITLE
fix(#50): use current diff for accurate commit message generation

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -3,6 +3,7 @@ package git
 type Git interface {
 	GetBranchName() (string, error)
 	GetDiff() (string, error)
+	GetCurrentDiff() (string, error)
 	GetBaseBranchName() (string, error)
 	GetCurrentCommitMessage() (string, error)
 	AppendToCommit() error

--- a/git/mockgit.go
+++ b/git/mockgit.go
@@ -17,6 +17,10 @@ func (m *MockGit) GetDiff() (string, error) {
 	return "mock-diff", nil
 }
 
+func (m *MockGit) GetCurrentDiff() (string, error) {
+	return "current-mock-diff", nil
+}
+
 func (m *MockGit) CommitChanges(messages ...string) error {
 	return nil
 }

--- a/git/mockgit_test.go
+++ b/git/mockgit_test.go
@@ -49,6 +49,17 @@ func TestMockGetDiff(t *testing.T) {
 	}
 }
 
+func TestMockGetCurrentDiff(t *testing.T) {
+	git := MockGit{}
+	output, err := git.GetCurrentDiff()
+	if err != nil {
+		panic(err)
+	}
+	if output != "current-mock-diff" {
+		t.Fatal("Expected the diff 'mock-diff'")
+	}
+}
+
 func TestMockGetAllRemoteURLs(t *testing.T) {
 	git := MockGit{}
 	output, err := git.GetAllRemoteURLs()

--- a/git/realgit.go
+++ b/git/realgit.go
@@ -105,6 +105,19 @@ func (r *RealGit) GetDiff() (string, error) {
 	}
 }
 
+func (r *RealGit) GetCurrentDiff() (string, error) {
+	unstaged, unErr := r.shell.RunCommandInDir(r.dir, "git", "diff")
+	if unErr != nil {
+		return "", unErr
+	}
+	staged, stErr := r.shell.RunCommandInDir(r.dir, "git", "diff", "--cached")
+	if stErr != nil {
+		return "", stErr
+	}
+	diff := unstaged + "\n" + staged
+	return diff, nil
+}
+
 func (r *RealGit) GetCurrentCommitMessage() (string, error) {
 	out, err := r.shell.RunCommandInDir(r.dir, "git", "log", "-1", "--pretty=%B")
 	if err != nil {

--- a/git/realgit_test.go
+++ b/git/realgit_test.go
@@ -199,6 +199,36 @@ func TestRealGetDiff(t *testing.T) {
 	}
 }
 
+func TestRealGetCurrentDiff(t *testing.T) {
+	repoDir, cleanup := setupTestRepo(t)
+	defer cleanup()
+	filePath := filepath.Join(repoDir, "file.txt")
+	if err := os.WriteFile(filePath, []byte("Hello, World!"), 0644); err != nil {
+		t.Fatalf("Error writing to file: %v", err)
+	}
+	cmd := exec.Command("git", "add", ".")
+	cmd.Dir = repoDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Error running command: %v", err)
+	}
+	cmd = exec.Command("git", "commit", "-m", "Add hello world")
+	cmd.Dir = repoDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Error running command: %v", err)
+	}
+	if err := os.WriteFile(filePath, []byte("Hello, Git!"), 0644); err != nil {
+		t.Fatalf("Error writing to file: %v", err)
+	}
+	gitService := NewRealGit(&executor.RealExecutor{}, repoDir)
+	diff, err := gitService.GetDiff()
+	if err != nil {
+		t.Fatalf("Error getting diff: %v", err)
+	}
+	if diff == "Hello, Git!" {
+		t.Fatal("Expected non-empty diff")
+	}
+}
+
 func TestRealGetCurrentCommitMessage(t *testing.T) {
 	repoDir, cleanup := setupTestRepo(t)
 	defer cleanup()

--- a/main.go
+++ b/main.go
@@ -102,6 +102,7 @@ func squash(gitService git.Git, shell executor.Executor, aiService ai.AI) {
 	commit(gitService, shell, false, aiService)
 }
 
+// Comment
 func commit(gitService git.Git, shell executor.Executor, noAI bool, aiService ai.AI) {
 	if noAI {
 		err := gitService.CommitChanges()
@@ -113,12 +114,10 @@ func commit(gitService git.Git, shell executor.Executor, noAI bool, aiService ai
 		if err != nil {
 			log.Fatalf("Error getting branch name: %v", err)
 		}
-
-		diff, diffErr := gitService.GetDiff()
+		diff, diffErr := gitService.GetCurrentDiff()
 		if diffErr != nil {
 			log.Fatalf("Error getting diff: %v", err)
 		}
-
 		msg, cerr := aiService.GenerateCommitMessage(branchName, diff)
 		if cerr != nil {
 			log.Fatalf("Error generating commit message: %v", err)
@@ -126,12 +125,6 @@ func commit(gitService git.Git, shell executor.Executor, noAI bool, aiService ai
 		if err := gitService.CommitChanges(msg); err != nil {
 			log.Fatalf("Error committing changes: %v", err)
 		}
-		// issueNumber := extractIssueNumber(branchName)
-		// prompt := fmt.Sprintf(ai.GenerateCommitPrompt, issueNumber, issueNumber)
-		// _, shellErr := shell.RunCommand("aider", "--commit", "--commit-prompt", prompt)
-		// if shellErr != nil {
-		// 	log.Fatalf("Error executing aider --commit: %v", err)
-		// }
 	}
 	heal(gitService, shell)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/volodya-lombrozo/aidy/github"
 )
 
-// Here I added comment
 func TestHeal(t *testing.T) {
 	mockGit := &git.MockGit{}
 	mockExecutor := &executor.MockExecutor{


### PR DESCRIPTION
This PR updates the commit message generation to use `GetCurrentDiff` for accurate diffs. Closes #50