### PR TITLE
fix(#55): check all remote addresses for issue detection

### DIFF
--- a/github/realgithub.go
+++ b/github/realgithub.go
@@ -40,31 +40,37 @@ func (r *RealGithub) IssueDescription(number string) string {
 		panic(gerr)
 	}
 	credentials := parseOwnerRepoPairs(urls)
-	url := fmt.Sprintf("%s/repos/%s/%s/issues/%s", r.baseURL, credentials[0][0], credentials[0][1], number)
-	log.Printf("Tying to get an isse description by using the following url: %s\n", url)
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return fmt.Sprintf("Error creating request: %v", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+r.authToken)
-	resp, err := r.client.Do(req)
-	if err != nil {
-		return fmt.Sprintf("Error fetching issue description: %v", err)
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			log.Printf("Error closing response body: %v", err)
-		}
-	}()
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Sprintf("Error reading response body: %v", err)
-	}
-	var issue Issue
-	err = json.Unmarshal(body, &issue)
-	if err != nil {
-		return fmt.Sprintf("Error unmarshaling issue JSON: %v", err)
-	}
+    var issue Issue
+    for _, cred := range credentials {
+        url := fmt.Sprintf("%s/repos/%s/%s/issues/%s", r.baseURL, cred[0], cred[1], number)
+        log.Printf("Tying to get an isse description by using the following url: %s\n", url)
+        req, err := http.NewRequest("GET", url, nil)
+        if err != nil {
+            return fmt.Sprintf("Error creating request: %v", err)
+        }
+        req.Header.Set("Authorization", "Bearer "+r.authToken)
+        resp, err := r.client.Do(req)
+        if err != nil {
+            return fmt.Sprintf("Error fetching issue description: %v", err)
+        }
+        defer func() {
+            if err := resp.Body.Close(); err != nil {
+                log.Printf("Error closing response body: %v", err)
+            }
+        }()
+        if resp.StatusCode != http.StatusOK {
+            fmt.Printf("Skipping %s: status %s\n", url, resp.Status)
+            continue
+        }
+        body, err := io.ReadAll(resp.Body)
+        if err != nil {
+            return fmt.Sprintf("Error reading response body: %v", err)
+        }
+        err = json.Unmarshal(body, &issue)
+        if err != nil {
+            return fmt.Sprintf("Error unmarshaling issue JSON: %v", err)
+        }
+    }
 	fmt.Printf("Title: %s\nBody: %s\n", issue.Title, issue.Body)
 	return fmt.Sprintf("Title: '%s'\nBody: '%s'", issue.Title, issue.Body)
 }


### PR DESCRIPTION
This PR updates the `IssueDescription` method to check all remote addresses for issue descriptions instead of just the first one. Closes #55