### PR TITLE
feat(#21): use aider config as fallback for token retrieval

### DIFF
--- a/config/aiderconfig.go
+++ b/config/aiderconfig.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"gopkg.in/yaml.v2"
+	"os"
+)
+
+type AiderConfig struct {
+    Model        string `yaml:"model"`
+    OpenaiApiKey string `yaml:"openai-api-key"`
+}
+
+func NewAiderConf(filepath string) *AiderConfig {
+	configData, err := os.ReadFile(filepath)
+	if err != nil {
+		panic(err)
+	}
+	var config AiderConfig
+	err = yaml.Unmarshal(configData, &config)
+	if err != nil {
+		panic(err)
+	}
+	return &config
+}
+
+func (c *AiderConfig) GetOpenAIAPIKey() (string, error) {
+	return c.OpenaiApiKey, nil
+}
+
+func (c *AiderConfig) GetGithubAPIKey() (string, error) {
+	return "", nil
+}
+
+func (c *AiderConfig) GetModel() (string, error) {
+    model := c.Model
+    return model, nil
+}
+

--- a/config/aiderconfig_test.go
+++ b/config/aiderconfig_test.go
@@ -1,0 +1,63 @@
+package config
+
+import (
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+const example = `
+model: 4o
+openai-api-key: secret-key
+`
+
+func TestAiderGetOpenAIAPIKey(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "configtest")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			t.Fatalf("Error removing temp directory: %v", err)
+		}
+	}()
+
+	configFilePath := tempDir + "/config.yml"
+	configContent := []byte(example)
+	err = os.WriteFile(configFilePath, configContent, 0644)
+	if err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	config := NewAiderConf(configFilePath)
+
+	apiKey, err := config.GetOpenAIAPIKey()
+	assert.NoError(t, err, "Error should be nil")
+	assert.Equal(t, "secret-key", apiKey, "API key should match")
+}
+
+
+func TestAiderGetModel(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "configtest")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			t.Fatalf("Error removing temp directory: %v", err)
+		}
+	}()
+
+	configFilePath := tempDir + "/config.yml"
+	configContent := []byte(example)
+	err = os.WriteFile(configFilePath, configContent, 0644)
+	if err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	config := NewAiderConf(configFilePath)
+
+	apiKey, err := config.GetModel()
+	assert.NoError(t, err, "Error should be nil")
+	assert.Equal(t, "4o", apiKey, "Model should match")
+}

--- a/main.go
+++ b/main.go
@@ -18,14 +18,8 @@ func main() {
 	if len(os.Args) < 2 {
 		log.Fatal("Error: No command provided. Use 'aidy help' for usage.")
 	}
-	command := os.Args[1]
-
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		log.Fatalf("Error getting home directory: %v", err)
-	}
-	configPath := fmt.Sprintf("%s/.aidy.conf.yml", homeDir)
-	yamlConfig := config.NewConf(configPath)
+    command := os.Args[1]
+	yamlConfig := readConfiguration() 
 	apiKey, err := yamlConfig.GetOpenAIAPIKey()
 	if err != nil {
 		log.Fatalf("Error getting OpenAI API key: %v", err)
@@ -71,6 +65,28 @@ func main() {
     default:
 		log.Fatalf("Error: Unknown command '%s'. Use 'aidy help' for usage.\n", command)
 	}
+}
+
+func readConfiguration() config.Config {
+    homeDir, err := os.UserHomeDir()
+    if err != nil {
+        log.Fatalf("Error getting home directory: %v", err)
+    }
+    var conf config.Config
+    aider := false 
+    for _, arg := range os.Args {
+        if arg == "--aider" {
+            aider = true
+        }
+    }
+    if aider {
+        configPath := fmt.Sprintf("%s/.aider.conf.yml", homeDir)
+        conf = config.NewAiderConf(configPath)
+    } else {
+        configPath := fmt.Sprintf("%s/.aidy.conf.yml", homeDir)
+        conf = config.NewConf(configPath)
+    }
+    return conf
 }
 
 func printConfig(cfg config.Config) {


### PR DESCRIPTION
This PR implements the use of `aider` config as a fallback for token retrieval, enhancing reliability.

Closes #21