### PR TITLE
fix(#51): include staged changes in diff for commit messages

### DIFF
--- a/git/realgit.go
+++ b/git/realgit.go
@@ -96,7 +96,7 @@ func (r *RealGit) GetDiff() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("error determining base branch: %v", err)
 	}
-	out, diffErr := r.shell.RunCommandInDir(r.dir, "git", "diff", baseBranch)
+	out, diffErr := r.shell.RunCommandInDir(r.dir, "git", "diff", baseBranch, "--cached")
 	if diffErr != nil {
 		return "", err
 	} else {

--- a/main.go
+++ b/main.go
@@ -189,7 +189,11 @@ func commit(gitService git.Git, shell executor.Executor, noAI bool, aiService ai
 		if err != nil {
 			log.Fatalf("Error getting branch name: %v", err)
 		}
-		diff, diffErr := gitService.GetCurrentDiff()
+        _, addErr := shell.RunCommand("git", "add", "--all")
+        if addErr != nil {
+            log.Fatalf("Error adding git files: %v", err)
+        }
+        diff, diffErr := gitService.GetCurrentDiff()
 		if diffErr != nil {
 			log.Fatalf("Error getting diff: %v", err)
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -44,6 +44,7 @@ func TestSquash(t *testing.T) {
 
 	expectedCommands := []string{
 		"git reset --soft main",
+        "git add --all",
 		"git commit --amend -m feat(#41): current commit message",
 	}
 
@@ -93,6 +94,7 @@ func TestCommit(t *testing.T) {
 	commit(mockGit, mockExecutor, false, mockAI)
 
 	expectedCommands := []string{
+        "git add --all",
 		"git commit --amend -m feat(#41): current commit message",
 	}
 	for i, expectedCommand := range expectedCommands {


### PR DESCRIPTION
This PR ensures new files are included in the diff by using `git add --all` and `--cached` flag, providing complete changes for commit messages.

Closes #51