### PR TITLE
fix(#71): Remove unnecessary quotes from generated titles and bodies

### DIFF
--- a/ai/mockai.go
+++ b/ai/mockai.go
@@ -3,7 +3,7 @@ package ai
 type MockAI struct{}
 
 func (m *MockAI) GenerateTitle(branchName string, diff string, issue string) (string, error) {
-	return "Mock Title for " + branchName, nil
+	return "'Mock Title for " + branchName + "'", nil
 }
 
 func (m *MockAI) GenerateBody(branchName string, diff string, issue string) (string, error) {
@@ -11,7 +11,7 @@ func (m *MockAI) GenerateBody(branchName string, diff string, issue string) (str
 }
 
 func (m *MockAI) GenerateIssueTitle(userInput string) (string, error) {
-	return "Mock Issue Title for " + userInput, nil
+	return "'Mock Issue Title for " + userInput + "'", nil
 }
 
 func (m *MockAI) GenerateIssueBody(userInput string) (string, error) {

--- a/ai/mockai_test.go
+++ b/ai/mockai_test.go
@@ -32,7 +32,7 @@ func TestMockGenerateLabels(t *testing.T) {
 func TestMockGenerateTitle(t *testing.T) {
 	mockAI := &MockAI{}
 	branchName := "feature-branch"
-	expected := "Mock Title for " + branchName
+    expected := "'Mock Title for " + branchName + "'"
 
 	title, err := mockAI.GenerateTitle(branchName, "diff", "issue")
 	if err != nil {
@@ -46,7 +46,7 @@ func TestMockGenerateTitle(t *testing.T) {
 func TestMockGenerateIssueTitle(t *testing.T) {
 	mockAI := &MockAI{}
 	userInput := "issue input"
-	expected := "Mock Issue Title for " + userInput
+    expected := "'Mock Issue Title for " + userInput + "'"
 
 	title, err := mockAI.GenerateIssueTitle(userInput)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -159,9 +159,9 @@ func issue(userInput string, aiService ai.AI, gh github.Github) {
 		log.Fatalf("Error generating labels: %v", err)
 	}
 	if len(suitable) > 0 {
-		fmt.Printf("\n%s\n", escapeBackticks(fmt.Sprintf("gh issue create --title \"%s\" --body \"%s\" --label \"%s\"", title, body, strings.Join(suitable, ","))))
+		fmt.Printf("\n%s\n", escapeBackticks(fmt.Sprintf("gh issue create --title \"%s\" --body \"%s\" --label \"%s\"", healQoutes(title), healQoutes(body), strings.Join(suitable, ","))))
 	} else {
-		fmt.Printf("\n%s\n", escapeBackticks(fmt.Sprintf("gh issue create --title \"%s\" --body \"%s\"", title, body)))
+		fmt.Printf("\n%s\n", escapeBackticks(fmt.Sprintf("gh issue create --title \"%s\" --body \"%s\"", healQoutes(title), healQoutes(body))))
 	}
 }
 
@@ -226,7 +226,7 @@ func pull_request(gitService git.Git, aiService ai.AI, gh github.Github) {
 	if err != nil {
 		log.Fatalf("Error generating body: %v", err)
 	}
-	fmt.Printf("\n%s\n", escapeBackticks(fmt.Sprintf("gh pr create --title \"%s\" --body \"%s\"", title, body)))
+	fmt.Printf("\n%s\n", escapeBackticks(fmt.Sprintf("gh pr create --title \"%s\" --body \"%s\"", healQoutes(title), healQoutes(body))))
 }
 
 func heal(gitService git.Git, shell executor.Executor) {
@@ -245,6 +245,10 @@ func heal(gitService git.Git, shell executor.Executor) {
 	if err != nil {
 		log.Fatalf("Error amending commit message: %v", err)
 	}
+}
+
+func healQoutes(text string) string {
+    return strings.Trim(text, `"'`)
 }
 
 func appendToCommit(gitService git.Git) {

--- a/main_test.go
+++ b/main_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/volodya-lombrozo/aidy/ai"
 	"github.com/volodya-lombrozo/aidy/executor"
 	"github.com/volodya-lombrozo/aidy/git"
@@ -81,6 +82,13 @@ func TestPullRequest(t *testing.T) {
 	if strings.TrimSpace(output) != strings.TrimSpace(expected) {
 		t.Errorf("Unexpected output:\n%s", output)
 	}
+}
+
+func TestHealQoutes(t *testing.T) {
+    message := healQoutes("\"with \" qoutes\"")
+    assert.Equal(t, "with \" qoutes", message)
+    message = healQoutes("'with ' qoutes'")
+    assert.Equal(t, "with ' qoutes", message)
 }
 
 func TestCommit(t *testing.T) {


### PR DESCRIPTION
This PR removes unnecessary quotes from AI-generated titles in `issue` and `pr` commands by implementing a `healQoutes` helper function.

Closes #71