### PR TITLE
fix(#67): correct Codecov badge URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Aidy
-[![codecov](https://codecov.io/gh/volodya-lombrozo/jtcop/branch/main/graph/badge.svg)](https://codecov.io/gh/volodya-lombrozo/aidy)
+
+[![codecov](https://codecov.io/gh/volodya-lombrozo/aidy/branch/main/graph/badge.svg)](https://codecov.io/gh/volodya-lombrozo/aidy)
 
 Aidy is a command-line tool that generates GitHub pull request commands with AI-generated titles and body messages.
 


### PR DESCRIPTION
This PR fixes the incorrect `Codecov` badge URL in README.md to display accurate test coverage statistics.

Closes #67