### PR TITLE
refactor(#79): Use cache in IssueDescription like Labels does

### DIFF
--- a/config/newconfig_test.go
+++ b/config/newconfig_test.go
@@ -90,6 +90,7 @@ func TestNewConfig(t *testing.T) {
 	assert.Equal(t, "true", modelDeepseek["use-streaming"])
 	assert.Equal(t, "experimental-mode", modelDeepseek["custom-option"])
 }
+
 func TestGetOpenAIAPIKey(t *testing.T) {
 	tempDir, err := os.MkdirTemp("", "configtest")
 	if err != nil {

--- a/github/realgithub.go
+++ b/github/realgithub.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"strings"
 )
 
 type RealGithub struct {
@@ -19,12 +18,12 @@ type RealGithub struct {
 	ch         cache.Cache
 }
 
-type Issue struct {
+type issue struct {
 	Title string `json:"title"`
 	Body  string `json:"body"`
 }
 
-type Label struct {
+type label struct {
 	Id          int64  `json:"id"`
 	Node        string `json:"node_id"`
 	Url         string `json:"url"`
@@ -47,15 +46,11 @@ func (r *RealGithub) IssueDescription(number string) string {
 	if r.gitService == nil {
 		panic("Git service isn't set")
 	}
-	urls, gerr := r.gitService.GetAllRemoteURLs()
-	if gerr != nil {
-		panic(gerr)
-	}
-	credentials := parseOwnerRepoPairs(urls)
-	var issue Issue
-	for _, cred := range credentials {
-		url := fmt.Sprintf("%s/repos/%s/%s/issues/%s", r.baseURL, cred[0], cred[1], number)
-		log.Printf("Tying to get an isse description by using the following url: %s\n", url)
+	var task issue
+	target, ok := r.ch.Get("target")
+	if ok {
+		url := fmt.Sprintf("%s/repos/%s/issues/%s", r.baseURL, target, number)
+		log.Printf("Trying to get an issue description using the following URL: %s\n", url)
 		req, err := http.NewRequest("GET", url, nil)
 		if err != nil {
 			return fmt.Sprintf("Error creating request: %v", err)
@@ -71,41 +66,36 @@ func (r *RealGithub) IssueDescription(number string) string {
 			}
 		}()
 		if resp.StatusCode != http.StatusOK {
-			fmt.Printf("Skipping %s: status %s\n", url, resp.Status)
-			continue
+			log.Fatalf("Cannot retrieve issue using the following URL: '%s'. Response: '%s'", url, resp.Status)
 		}
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return fmt.Sprintf("Error reading response body: %v", err)
 		}
-		err = json.Unmarshal(body, &issue)
+		err = json.Unmarshal(body, &task)
 		if err != nil {
 			return fmt.Sprintf("Error unmarshaling issue JSON: %v", err)
 		}
+	} else {
+		log.Fatalf("Cannot find a target repository to search for issue '%s'", number)
 	}
-	fmt.Printf("Title: %s\nBody: %s\n", issue.Title, issue.Body)
-	return fmt.Sprintf("Title: '%s'\nBody: '%s'", issue.Title, issue.Body)
+	fmt.Printf("Title: %s\nBody: %s\n", task.Title, task.Body)
+	return fmt.Sprintf("Title: '%s'\nBody: '%s'", task.Title, task.Body)
 }
 
 func (r *RealGithub) Labels() []string {
 	if r.gitService == nil {
 		panic("Git service isn't set")
 	}
-	urls, gerr := r.gitService.GetAllRemoteURLs()
-	if gerr != nil {
-		panic(gerr)
-	}
-	credentials := parseOwnerRepoPairs(urls)
-	var labels []Label
-
+	var labels []label
 	target, ok := r.ch.Get("target")
 	if ok {
-		log.Printf("Choosing labels from the '%s'\n", target)
+		log.Printf("Choosing labels from '%s'\n", target)
 		url := fmt.Sprintf("%s/repos/%s/labels", r.baseURL, target)
-		log.Printf("Tying to get a repo labels by using the following url: %s\n", url)
+		log.Printf("Trying to get repository labels using the following URL: %s\n", url)
 		req, err := http.NewRequest("GET", url, nil)
 		if err != nil {
-			panic(err)
+            log.Fatalf("Cannot create a new GET request to retrieve labels, because of '%v'", err)
 		}
 		req.Header.Set("Authorization", "Bearer "+r.authToken)
 		resp, err := r.client.Do(req)
@@ -118,7 +108,7 @@ func (r *RealGithub) Labels() []string {
 			}
 		}()
 		if resp.StatusCode != http.StatusOK {
-			log.Fatalf("Skipping %s: status %s\n", url, resp.Status)
+			log.Fatalf("Skipping %s: Status %s\n", url, resp.Status)
 		}
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
@@ -129,84 +119,11 @@ func (r *RealGithub) Labels() []string {
 			log.Fatalf("Error unmarshaling issue JSON: %v", err)
 		}
 	} else {
-		for _, cred := range credentials {
-			url := fmt.Sprintf("%s/repos/%s/%s/labels", r.baseURL, cred[0], cred[1])
-			log.Printf("Tying to get a repo labels by using the following url: %s\n", url)
-			req, err := http.NewRequest("GET", url, nil)
-			if err != nil {
-				panic(err)
-			}
-			req.Header.Set("Authorization", "Bearer "+r.authToken)
-			resp, err := r.client.Do(req)
-			if err != nil {
-				log.Fatalf("Error fetching issue description: %v", err)
-			}
-			defer func() {
-				if err := resp.Body.Close(); err != nil {
-					log.Printf("Error closing response body: %v", err)
-				}
-			}()
-			if resp.StatusCode != http.StatusOK {
-				fmt.Printf("Skipping %s: status %s\n", url, resp.Status)
-				continue
-			}
-			body, err := io.ReadAll(resp.Body)
-			if err != nil {
-				log.Fatalf("Error reading response body: %v", err)
-			}
-			err = json.Unmarshal(body, &labels)
-			if err != nil {
-				log.Fatalf("Error unmarshaling issue JSON: %v", err)
-			}
-		}
+		log.Fatalf("Cannot determine where to get labels. Please set the target repository.")
 	}
 	var res []string
 	for _, label := range labels {
 		res = append(res, label.Name)
 	}
-	fmt.Printf("Labels: %s\n", strings.Join(res, ", "))
 	return res
-}
-
-func parseOwnerRepoPairs(urls []string) [][2]string {
-	var pairs [][2]string
-	seen := make(map[string]struct{})
-
-	for _, url := range urls {
-		var owner, repo string
-
-		switch {
-		case strings.HasPrefix(url, "git@"):
-			// SSH format: git@github.com:owner/repo.git
-			parts := strings.SplitN(url, ":", 2)
-			if len(parts) != 2 {
-				continue
-			}
-			pathParts := strings.Split(strings.TrimSuffix(parts[1], ".git"), "/")
-			if len(pathParts) != 2 {
-				continue
-			}
-			owner, repo = pathParts[0], pathParts[1]
-
-		case strings.HasPrefix(url, "https://"):
-			// HTTPS format: https://github.com/owner/repo.git
-			p := strings.TrimPrefix(url, "https://github.com/")
-			pathParts := strings.Split(strings.TrimSuffix(p, ".git"), "/")
-			if len(pathParts) != 2 {
-				continue
-			}
-			owner, repo = pathParts[0], pathParts[1]
-
-		default:
-			continue
-		}
-
-		key := owner + "/" + repo
-		if _, ok := seen[key]; !ok {
-			pairs = append(pairs, [2]string{owner, repo})
-			seen[key] = struct{}{}
-		}
-	}
-
-	return pairs
 }


### PR DESCRIPTION
Refactors `IssueDescription()` to use the `cache` module for target repository lookup, matching `Labels()` behavior.

Closes #79