### PR TITLE
refactor(#86): Introduce AidyCache interface to abstract cache access

### DIFF
--- a/cache/aidycache.go
+++ b/cache/aidycache.go
@@ -1,0 +1,71 @@
+package cache
+
+import "log"
+
+type AidyCache interface {
+	Remote() string
+	WithRemote(string)
+	Summary() string
+	WithSummary(string)
+}
+
+type aidyCache struct {
+	ch Cache
+}
+
+func NewAidyCache(ch Cache) AidyCache {
+	return &aidyCache{ch: ch}
+}
+
+func (a *aidyCache) Remote() string {
+	repo, ok := a.ch.Get("target")
+	if ok && repo != "" {
+		return repo
+	} else {
+		return ""
+	}
+}
+
+func (a *aidyCache) WithRemote(remote string) {
+	err := a.ch.Set("target", remote)
+	if err != nil {
+		log.Fatalf("Can't save the project remote address, because '%v'", err)
+	}
+}
+
+func (a *aidyCache) Summary() string {
+	summary, ok := a.ch.Get("summary")
+	if ok && summary != "" {
+		return summary
+	} else {
+		return ""
+	}
+}
+
+func (a *aidyCache) WithSummary(summary string) {
+	err := a.ch.Set("summary", summary)
+	if err != nil {
+		log.Fatalf("Can't save the project summary, because '%v'", err)
+	}
+}
+
+type mockAidyCache struct {
+}
+
+func NewMockAidyCache() AidyCache {
+	return &mockAidyCache{}
+}
+
+func (a *mockAidyCache) Remote() string {
+	return "mock/remote"
+}
+
+func (a *mockAidyCache) WithRemote(remote string) {
+}
+
+func (a *mockAidyCache) Summary() string {
+	return "mock summary"
+}
+
+func (a *mockAidyCache) WithSummary(summary string) {
+}

--- a/cache/aidycache_test.go
+++ b/cache/aidycache_test.go
@@ -1,0 +1,71 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mapCache struct {
+	store map[string]string
+}
+
+func (m *mapCache) Get(key string) (string, bool) {
+	val, ok := m.store[key]
+	return val, ok
+}
+
+func (m *mapCache) Set(key, value string) error {
+	m.store[key] = value
+	return nil
+}
+
+func TestAidyCache_Remote(t *testing.T) {
+	mc := &mapCache{store: make(map[string]string)}
+	ac := NewAidyCache(mc)
+
+	err := mc.Set("target", "https://example.com/repo.git")
+	require.NoError(t, err)
+	remote := ac.Remote()
+	assert.Equal(t, "https://example.com/repo.git", remote, "expected remote to be 'https://example.com/repo.git'")
+
+	err = mc.Set("target", "")
+	require.NoError(t, err)
+	remote = ac.Remote()
+	assert.Equal(t, "", remote, "expected remote to be ''")
+}
+
+func TestAidyCache_WithRemote(t *testing.T) {
+	mc := &mapCache{store: make(map[string]string)}
+	ac := NewAidyCache(mc)
+
+	ac.WithRemote("https://example.com/repo.git")
+	remote, ok := mc.Get("target")
+	assert.True(t, ok)
+	assert.Equal(t, "https://example.com/repo.git", remote, "expected remote to be 'https://example.com/repo.git'")
+}
+
+func TestAidyCache_Summary(t *testing.T) {
+	mc := &mapCache{store: make(map[string]string)}
+	ac := NewAidyCache(mc)
+
+	err := mc.Set("summary", "Project Summary")
+	require.NoError(t, err)
+	summary := ac.Summary()
+	assert.Equal(t, "Project Summary", summary, "expected summary to be 'Project Summary'")
+
+	err = mc.Set("summary", "")
+	require.NoError(t, err)
+	summary = ac.Summary()
+	assert.Equal(t, "", summary, "expected summary to be ''")
+}
+
+func TestAidyCache_WithSummary(t *testing.T) {
+	mc := &mapCache{store: make(map[string]string)}
+	ac := NewAidyCache(mc)
+
+	ac.WithSummary("Project Summary")
+	summary, _ := mc.Get("summary")
+	assert.Equal(t, "Project Summary", summary, "expected summary to be 'Project Summary'")
+}

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -46,7 +46,7 @@ func TestRealGithub_IssueDescription(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	realGithub := NewRealGithub(ts.URL, &git.MockGit{}, "", cache.NewMockCache())
+	realGithub := NewRealGithub(ts.URL, &git.MockGit{}, "", cache.NewMockAidyCache())
 
 	issueNumber := "123"
 	description := realGithub.IssueDescription(issueNumber)
@@ -87,7 +87,7 @@ func TestRealGithub_Labels(t *testing.T) {
 		}
 	}))
 	defer ts.Close()
-	realGithub := NewRealGithub(ts.URL, &git.MockGit{}, "", cache.NewMockCache())
+	realGithub := NewRealGithub(ts.URL, &git.MockGit{}, "", cache.NewMockAidyCache())
 
 	labels := realGithub.Labels()
 
@@ -98,7 +98,7 @@ func TestRealGithub_Labels(t *testing.T) {
 }
 
 func TestRealGithub_Remotes(t *testing.T) {
-	gh := NewRealGithub("", &git.MockGit{}, "", cache.NewMockCache())
+	gh := NewRealGithub("", &git.MockGit{}, "", cache.NewMockAidyCache())
 
 	actual := gh.Remotes()
 

--- a/github/realgithub.go
+++ b/github/realgithub.go
@@ -18,7 +18,7 @@ type RealGithub struct {
 	baseURL    string
 	gitService git.Git
 	authToken  string
-	ch         cache.Cache
+	ch         cache.AidyCache
 }
 
 type issue struct {
@@ -35,7 +35,7 @@ type label struct {
 	Description string `json:"description"`
 }
 
-func NewRealGithub(baseURL string, gitService git.Git, authToken string, ch cache.Cache) *RealGithub {
+func NewRealGithub(baseURL string, gitService git.Git, authToken string, ch cache.AidyCache) *RealGithub {
 	return &RealGithub{
 		client:     &http.Client{},
 		baseURL:    baseURL,
@@ -50,8 +50,8 @@ func (r *RealGithub) IssueDescription(number string) string {
 		panic("Git service isn't set")
 	}
 	var task issue
-	target, ok := r.ch.Get("target")
-	if ok {
+	target := r.ch.Remote()
+	if target != "" {
 		url := fmt.Sprintf("%s/repos/%s/issues/%s", r.baseURL, target, number)
 		log.Printf("Trying to get an issue description using the following URL: %s\n", url)
 		req, err := http.NewRequest("GET", url, nil)
@@ -91,8 +91,8 @@ func (r *RealGithub) Labels() []string {
 		panic("Git service isn't set")
 	}
 	var labels []label
-	target, ok := r.ch.Get("target")
-	if ok {
+	target := r.ch.Remote()
+	if target != "" {
 		log.Printf("Choosing labels from '%s'\n", target)
 		url := fmt.Sprintf("%s/repos/%s/labels", r.baseURL, target)
 		log.Printf("Trying to get repository labels using the following URL: %s\n", url)


### PR DESCRIPTION
Introduces `AidyCache` interface to abstract cache operations for remote repository and summary data, replacing direct cache access throughout the codebase.

Closes #86