### PR TITLE
feat(#75): Add clean command to clear cache

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -108,6 +109,8 @@ func main() {
 		issue(userInput, aiService, gh, ch)
 	case "conf", "config":
 		printConfig(yamlConfig)
+	case "clean":
+		cleanCache()
 	default:
 		log.Fatalf("Error: Unknown command '%s'. Use 'aidy help' for usage.\n", command)
 	}
@@ -317,4 +320,16 @@ func extractIssueNumber(branchName string) string {
 
 func escapeBackticks(input string) string {
 	return strings.ReplaceAll(input, "`", "\\`")
+}
+
+func cleanCache() {
+	dir, err := os.Getwd()
+	if err != nil {
+		log.Fatalf("Can't understand what is the current directory, '%v'", err)
+	}
+	cache := filepath.Join(dir, ".aidy")
+	err = os.RemoveAll(cache)
+	if err != nil {
+		log.Fatalf("Can't clear '.aidy' directory, '%v'", err)
+	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"io"
-	"os"
 	"strings"
 	"testing"
 
@@ -14,6 +13,8 @@ import (
 	"github.com/volodya-lombrozo/aidy/executor"
 	"github.com/volodya-lombrozo/aidy/git"
 	"github.com/volodya-lombrozo/aidy/github"
+	"os"
+	"path/filepath"
 )
 
 func TestHeal(t *testing.T) {
@@ -33,6 +34,26 @@ func TestHeal(t *testing.T) {
 			t.Errorf("Expected command '%s', got '%s'", expectedCommand, mockExecutor.Commands[i])
 		}
 	}
+}
+
+func TestCleanCache(t *testing.T) {
+	tempDir := t.TempDir()
+	aidyDir := filepath.Join(tempDir, ".aidy")
+	err := os.Mkdir(aidyDir, 0755)
+	require.NoError(t, err, "Failed to create .aidy directory")
+
+	originalDir, err := os.Getwd()
+	require.NoError(t, err, "Failed to get current working directory")
+	defer func() {
+		_ = os.Chdir(originalDir)
+	}()
+	err = os.Chdir(tempDir)
+	require.NoError(t, err, "Failed to change working directory")
+
+	cleanCache()
+
+	_, err = os.Stat(aidyDir)
+	assert.True(t, os.IsNotExist(err), ".aidy directory should be removed")
 }
 
 func TestSquash(t *testing.T) {


### PR DESCRIPTION
Adds a `clean` command to remove the `.aidy` cache directory for maintenance and troubleshooting purposes.

Closes #75