### PR TITLE
feat(#91): Support PR references in GitHub issue linking

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -1,7 +1,7 @@
 package github
 
 type Github interface {
-	IssueDescription(number string) string
+	Description(number string) string
 	Labels() []string
 	Remotes() []string
 }

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -21,7 +21,7 @@ func TestMockGithub_IssueDescription(t *testing.T) {
 	issueNumber := "123"
 	expectedDescription := "Mock description for issue #" + issueNumber
 
-	description := mockGithub.IssueDescription(issueNumber)
+	description := mockGithub.Description(issueNumber)
 	if description != expectedDescription {
 		t.Errorf("expected %s, got %s", expectedDescription, description)
 	}
@@ -36,7 +36,7 @@ func TestMockGithub_Labels(t *testing.T) {
 	}
 }
 
-func TestRealGithub_IssueDescription(t *testing.T) {
+func TestRealGithub_Description(t *testing.T) {
 	// Create a test server to mock GitHub API
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -49,7 +49,7 @@ func TestRealGithub_IssueDescription(t *testing.T) {
 	realGithub := NewRealGithub(ts.URL, &git.MockGit{}, "", cache.NewMockAidyCache())
 
 	issueNumber := "123"
-	description := realGithub.IssueDescription(issueNumber)
+	description := realGithub.Description(issueNumber)
 	expectedDescription := fmt.Sprintf("Title: '%s'\nBody: '%s'", "Title", "Body")
 
 	if description != expectedDescription {

--- a/github/mockgithub.go
+++ b/github/mockgithub.go
@@ -2,7 +2,7 @@ package github
 
 type MockGithub struct{}
 
-func (m *MockGithub) IssueDescription(number string) string {
+func (m *MockGithub) Description(number string) string {
 	return "Mock description for issue #" + number
 }
 

--- a/github/realgithub.go
+++ b/github/realgithub.go
@@ -45,45 +45,56 @@ func NewRealGithub(baseURL string, gitService git.Git, authToken string, ch cach
 	}
 }
 
-func (r *RealGithub) IssueDescription(number string) string {
+func (r *RealGithub) Description(number string) string {
 	if r.gitService == nil {
 		panic("Git service isn't set")
 	}
 	var task issue
 	target := r.ch.Remote()
 	if target != "" {
-		url := fmt.Sprintf("%s/repos/%s/issues/%s", r.baseURL, target, number)
-		log.Printf("Trying to get an issue description using the following URL: %s\n", url)
-		req, err := http.NewRequest("GET", url, nil)
-		if err != nil {
-			return fmt.Sprintf("Error creating request: %v", err)
-		}
-		req.Header.Set("Authorization", "Bearer "+r.authToken)
-		resp, err := r.client.Do(req)
-		if err != nil {
-			return fmt.Sprintf("Error fetching issue description: %v", err)
-		}
-		defer func() {
-			if err := resp.Body.Close(); err != nil {
-				log.Printf("Error closing response body: %v", err)
-			}
-		}()
-		if resp.StatusCode != http.StatusOK {
-			log.Fatalf("Cannot retrieve issue using the following URL: '%s'. Response: '%s'", url, resp.Status)
-		}
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return fmt.Sprintf("Error reading response body: %v", err)
-		}
-		err = json.Unmarshal(body, &task)
-		if err != nil {
-			return fmt.Sprintf("Error unmarshaling issue JSON: %v", err)
-		}
+        task = r.issueDescription(number, target)
 	} else {
 		log.Fatalf("Cannot find a target repository to search for issue '%s'", number)
 	}
 	fmt.Printf("Title: %s\nBody: %s\n", task.Title, task.Body)
 	return fmt.Sprintf("Title: '%s'\nBody: '%s'", task.Title, task.Body)
+}
+
+
+// Here we retireve an issue or a PR description by thier number.
+// GitHub uses the same URL structure for both issues and pull requests in the context of their API
+// because every pull request is an issue under the hood.
+// In other words, GET "/issues/:number" works for both issues and PRs.
+func (r *RealGithub) issueDescription(number string, target string) issue {
+    url := fmt.Sprintf("%s/repos/%s/issues/%s", r.baseURL, target, number)
+    log.Printf("Trying to get an issue description using the following URL: %s\n", url)
+    req, err := http.NewRequest("GET", url, nil)
+    if err != nil {
+        log.Fatalf("Error creating request: %v", err)
+    }
+    req.Header.Set("Authorization", "Bearer "+r.authToken)
+    resp, err := r.client.Do(req)
+    if err != nil {
+        log.Fatalf("Error fetching issue description: %v", err)
+    }
+    defer func() {
+        if err := resp.Body.Close(); err != nil {
+            log.Printf("Error closing response body: %v", err)
+        }
+    }()
+    if resp.StatusCode != http.StatusOK {
+        log.Fatalf("Cannot retrieve issue using the following URL: '%s'. Response: '%s'", url, resp.Status)
+    }
+    body, err := io.ReadAll(resp.Body)
+    if err != nil {
+        log.Fatalf("Error reading response body: %v", err)
+    }
+    var task issue
+    err = json.Unmarshal(body, &task)
+    if err != nil {
+        log.Fatalf("Error unmarshaling issue JSON: %v", err)
+    }
+    return task 
 }
 
 func (r *RealGithub) Labels() []string {

--- a/main.go
+++ b/main.go
@@ -262,7 +262,7 @@ func pull_request(gitService git.Git, aiService ai.AI, gh github.Github, ch cach
 		log.Fatalf("Error getting git diff: %v", err)
 	}
 	nissue := extractIssueNumber(branchName)
-	issue := gh.IssueDescription(nissue)
+	issue := gh.Description(nissue)
 	title, err := aiService.GenerateTitle(branchName, diff, issue)
 	if err != nil {
 		log.Fatalf("Error generating title: %v", err)


### PR DESCRIPTION
Refactors GitHub issue description handling to work with both issues and PRs by renaming `IssueDescription` to `Description` and improving the underlying implementation.

Closes #91