### PR TITLE
feat(#96): Add prompt size limit for AI inputs

### DIFF
--- a/ai/ai.go
+++ b/ai/ai.go
@@ -8,3 +8,12 @@ type AI interface {
 	GenerateIssueLabels(issue string, available []string) ([]string, error)
 	GenerateCommitMessage(branchName string, diff string) (string, error)
 }
+
+func TrimPrompt(prompt string) string {
+    limit := 120 * 400
+	runes := []rune(prompt)
+	if len(runes) > limit {
+		return string(runes[:limit])
+	}
+	return prompt
+}

--- a/ai/ai_test.go
+++ b/ai/ai_test.go
@@ -1,0 +1,28 @@
+package ai
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTrimPrompt(t *testing.T) {
+	prompt := largePrompt()
+
+	trimmed := TrimPrompt(prompt)
+
+	assert.Equal(t, 48_000, len(trimmed))
+}
+
+func TestDoesNotTrimPrompt(t *testing.T) {
+	prompt := "Simple Prompt"
+
+	trimmed := TrimPrompt(prompt)
+
+	assert.Equal(t, "Simple Prompt", trimmed)
+}
+
+func largePrompt() string {
+	return strings.Repeat(string('a'), 100*500)
+}

--- a/ai/deepseek.go
+++ b/ai/deepseek.go
@@ -93,7 +93,7 @@ func (d *DeepSeekAI) sendPrompt(systemPrompt string, userPrompt string) (string,
 		Model: d.Model,
 		Messages: []chatMessage{
 			{Role: "system", Content: systemPrompt},
-			{Role: "user", Content: userPrompt},
+			{Role: "user", Content: TrimPrompt(userPrompt)},
 		},
 		Stream: false,
 	}

--- a/ai/openai.go
+++ b/ai/openai.go
@@ -72,7 +72,7 @@ func (o *MyOpenAI) generateText(prompt string) (string, error) {
 		Messages: []openai.ChatCompletionMessage{
 			{
 				Role:    "system",
-				Content: prompt,
+				Content: TrimPrompt(prompt),
 			},
 		},
 		Temperature: o.temperature,


### PR DESCRIPTION
Implements size limits for AI prompts by adding a `TrimPrompt` function that restricts input to 48,000 characters.

Closes #96