### PR TITLE
feat(#101): Check git installation before running aidy commands

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -9,4 +9,5 @@ type Git interface {
 	AppendToCommit() error
 	CommitChanges(messages ...string) error
 	Remotes() ([]string, error)
+    Installed() (bool, error)
 }

--- a/git/mockgit.go
+++ b/git/mockgit.go
@@ -33,3 +33,7 @@ func (m *MockGit) GetCurrentCommitMessage() (string, error) {
 func (r *MockGit) Remotes() ([]string, error) {
 	return []string{"https://github.com/volodya-lombrozo/aidy.git", "https://github.com/volodya-lombrozo/forked-aidy.git"}, nil
 }
+
+func (r *MockGit) Installed() (bool, error) {
+    return true, nil
+}

--- a/git/mockgit_test.go
+++ b/git/mockgit_test.go
@@ -74,3 +74,12 @@ func TestMockGetAllRemoteURLs(t *testing.T) {
 	assert.Equal(t, first, output[0])
 	assert.Equal(t, second, output[1])
 }
+
+func TestMockGitInstalled(t *testing.T) {
+    git := MockGit{}
+
+    installed, err  := git.Installed()
+
+    require.NoError(t,err)
+    assert.True(t, installed)
+}

--- a/git/realgit.go
+++ b/git/realgit.go
@@ -160,3 +160,11 @@ func (r *RealGit) Remotes() ([]string, error) {
 	}
 	return result, nil
 }
+
+func (r *RealGit) Installed() (bool, error) {
+    _, err  := r.shell.RunCommandInDir(r.dir, "git", "--version")
+    if err != nil {
+        return false, err
+    }
+    return true, nil
+}

--- a/git/realgit_test.go
+++ b/git/realgit_test.go
@@ -261,3 +261,14 @@ func TestRealGetCurrentCommitMessage(t *testing.T) {
 		t.Fatalf("Expected commit message '%s', got '%s'", commitMessage, message)
 	}
 }
+
+func TestRealGitInstalled(t *testing.T) {
+    repoDir, cleanup := setupTestRepo(t) 
+    defer cleanup()
+	gitService := NewRealGit(&executor.RealExecutor{}, repoDir)
+
+    installed, err  := gitService.Installed()
+
+    require.NoError(t, err)
+    assert.True(t, installed)
+}

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ func main() {
 	if len(os.Args) < 2 {
 		log.Fatal("Error: No command provided. Use 'aidy help' for usage.")
 	}
+
 	command := os.Args[1]
 	shell := &executor.RealExecutor{}
 
@@ -62,6 +63,7 @@ func main() {
 		aiService = ai.NewOpenAI(apiKey, model, 0.2)
 	}
 	gitService := git.NewRealGit(shell)
+    checkGitInstalled(gitService)
 	gh := github.NewRealGithub("https://api.github.com", gitService, githubKey, ch)
 	target := ch.Remote()
 	if target != "" {
@@ -400,5 +402,15 @@ func initSummary(aiService ai.AI, ch cache.AidyCache) {
         log.Printf("Project '%s' summary was successfully saved\n", shash) 
     } else {
         log.Printf("No need to update the project summary '%s'\n", shash) 
+    }
+}
+
+func checkGitInstalled(gitService git.Git) {
+    installed, err := gitService.Installed()
+    if err != nil {
+        log.Fatalf("Can't understand whether git is installed or not, because of '%v'", err)
+    }
+    if !installed {
+        log.Fatal("git is not installed on the system")
     }
 }


### PR DESCRIPTION
Adds git installation check at startup to ensure `aidy` commands run properly. Verifies git is available before proceeding with any operations.

Closes #101