### PR TITLE
feat(#100): Make summary flag optional for PR generation

### DIFF
--- a/ai/ai.go
+++ b/ai/ai.go
@@ -1,5 +1,7 @@
 package ai
 
+import "fmt"
+
 type AI interface {
 	PrTitle(branch string, diff string, issue string, summary string) (string, error)
 	PrBody(branch string, diff string, issue string, summary string) (string, error)
@@ -17,4 +19,12 @@ func TrimPrompt(prompt string) string {
 		return string(runes[:limit])
 	}
 	return prompt
+}
+
+func AppendSummary(prompt, summary string) string {
+    if summary == "" {
+        return prompt
+    }
+    appendix := fmt.Sprintf("\nThis is the project summary for which you do it:\n<summary>\n%s\n</summary>\n", summary)
+    return prompt + appendix
 }

--- a/ai/ai_test.go
+++ b/ai/ai_test.go
@@ -7,6 +7,47 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestAppendSummary(t *testing.T) {
+	tests := []struct {
+		name     string
+		prompt   string
+		summary  string
+		expected string
+	}{
+		{
+			name:     "No summary",
+			prompt:   "This is a prompt.",
+			summary:  "",
+			expected: "This is a prompt.",
+		},
+		{
+			name:   "With summary",
+			prompt: "This is a prompt.",
+			summary: "This is a summary.",
+			expected: "This is a prompt.\nThis is the project summary for which you do it:\n<summary>\nThis is a summary.\n</summary>\n",
+		},
+		{
+			name:   "Empty prompt with summary",
+			prompt: "",
+			summary: "This is a summary.",
+			expected: "\nThis is the project summary for which you do it:\n<summary>\nThis is a summary.\n</summary>\n",
+		},
+		{
+			name:     "Empty prompt and summary",
+			prompt:   "",
+			summary:  "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := AppendSummary(tt.prompt, tt.summary)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestTrimPrompt(t *testing.T) {
 	prompt := largePrompt()
 

--- a/ai/prompts.go
+++ b/ai/prompts.go
@@ -24,11 +24,6 @@ Carefully review both the diff and the issue description. Then, generate a PR ti
 - Use the imperative mood (e.g., "add feature", not "added feature" or "adding feature").
 - Keep the title within 72 characters.
 - Do not include explanations, comments, or line breaks. Return only the title line.
-
-Also, this is the project summary for which you need to create the PR title:
-<summary>
-%s
-</summary>
 `
 
 	GenerateBodyPrompt = `You are an expert software engineer who writes clear and professional pull request descriptions on GitHub.
@@ -61,11 +56,6 @@ Formatting rules:
 - Do not add section headers.
 - Do not include line breaks except before the "Closes" line.
 - Reply only with the pull request body — no additional text or explanations.
-
-Also, this is the project summary for which you need to create the PR body:
-<summary>
-%s
-</summary>
 `
 
 	GenerateCommitPrompt = `You are an expert software engineer who writes concise, one-line Git commit messages based on code diffs.
@@ -107,11 +97,6 @@ The title should:
 - Not exceed 72 characters
 
 Reply only with the issue title — no explanations, comments, or line breaks.
-
-Also, this is the project summary for which you need to create the issue title:
-<summary>
-%s
-</summary>
 `
 
 	GenerateIssueBodyPrompt = `You are an expert software engineer who writes clear and informative descriptions for GitHub issues.
@@ -131,12 +116,6 @@ The description should:
 - Use backticks for code or technical terms where appropriate
 
 Reply only with the issue body — no explanations, comments, or extra formatting.
-
-Also, this is the project summary for which you need to create the issue body:
-<summary>
-%s
-</summary>
-
 `
 
 	GenerateLabelsPrompt = `You are an expert software engineer who understands how to assign appropriate labels to GitHub issues.


### PR DESCRIPTION
This PR makes the project summary feature optional by introducing a `--summary` flag, allowing users to choose whether to include summaries in generated PRs and issues.

Closes #100