### PR TITLE
fix(#110): use full ref path when squashing to base branch

### DIFF
--- a/ai/openai.go
+++ b/ai/openai.go
@@ -35,7 +35,7 @@ func (o *MyOpenAI) PrBody(number, diff, issue, summary string) (string, error) {
 	return o.send(prompt, summary)
 }
 
-func (o *MyOpenAI) IssueTitle(input,  summary string) (string, error) {
+func (o *MyOpenAI) IssueTitle(input, summary string) (string, error) {
 	prompt := fmt.Sprintf(GenerateIssueTitlePrompt, input)
 	return o.send(prompt, summary)
 }
@@ -96,4 +96,3 @@ func (o *MyOpenAI) send(prompt, summary string) (string, error) {
 	}
 	return "", fmt.Errorf("no text generated")
 }
-

--- a/main.go
+++ b/main.go
@@ -236,7 +236,7 @@ func squash(gitService git.Git, shell executor.Executor, aiService ai.AI) {
 	if err != nil {
 		log.Fatalf("Error determining base branch: %v", err)
 	}
-	_, resetErr := shell.RunCommand("git", "reset", "--soft", baseBranch)
+	_, resetErr := shell.RunCommand("git", "reset", "--soft", "refs/heads/"+baseBranch)
 	if resetErr != nil {
 		log.Fatalf("Error executing git reset: %v", err)
 	}
@@ -262,7 +262,7 @@ func commit(gitService git.Git, shell executor.Executor, noAI bool, aiService ai
 		if diffErr != nil {
 			log.Fatalf("Error getting diff: %v", err)
 		}
-        nissue := extractIssueNumber(branchName)
+		nissue := extractIssueNumber(branchName)
 		msg, cerr := aiService.CommitMessage(nissue, diff)
 		if cerr != nil {
 			log.Fatalf("Error generating commit message: %v", cerr)

--- a/main_test.go
+++ b/main_test.go
@@ -67,7 +67,7 @@ func TestSquash(t *testing.T) {
 	squash(mockGit, mockExecutor, mockAI)
 
 	expectedCommands := []string{
-		"git reset --soft main",
+		"git reset --soft refs/heads/main",
 		"git add --all",
 		"git commit --amend -m feat(#41): current commit message",
 	}


### PR DESCRIPTION
Fixes `aidy sq` command to correctly handle squashing when there is ambiguity between tags and `main`/`master` branches by using full refspec paths.

Closes #110