### PR TITLE
fix(#108): improve quote healing to preserve inner backticks

### DIFF
--- a/main.go
+++ b/main.go
@@ -325,7 +325,31 @@ func heal(gitService git.Git, shell executor.Executor) {
 }
 
 func healQuotes(text string) string {
-	return strings.Trim(text, "\"'`")
+	clean := healQuote('`', text)
+	clean = healQuote('\'', clean)
+	clean = healQuote('"', clean)
+	return clean
+}
+
+func healQuote(open rune, text string) string {
+	stack := []int{}
+	runes := []rune(text)
+	size := len(runes)
+	for i := 0; i < size; i++ {
+		if runes[i] == open {
+			if len(stack) > 0 {
+				prev := stack[len(stack)-1]
+				if i == size-1 && prev == 0 {
+					return string(runes[1 : size-1])
+				} else {
+					stack = stack[:len(stack)-1]
+				}
+			} else {
+				stack = append(stack, i)
+			}
+		}
+	}
+	return text
 }
 
 func healPRBody(body string, issue string) string {

--- a/main_test.go
+++ b/main_test.go
@@ -107,13 +107,31 @@ func TestPullRequest(t *testing.T) {
 
 func TestHealQoutes(t *testing.T) {
 	message := healQuotes("\"with \" qoutes\"")
-	assert.Equal(t, "with \" qoutes", message)
+	assert.Equal(t, "\"with \" qoutes\"", message)
 
 	message = healQuotes("'with ' qoutes'")
-	assert.Equal(t, "with ' qoutes", message)
+	assert.Equal(t, "'with ' qoutes'", message)
 
 	message = healQuotes("`with ` qoutes`")
-	assert.Equal(t, "with ` qoutes", message)
+	assert.Equal(t, "`with ` qoutes`", message)
+}
+
+func TestHealQuotesParametrized(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"`feat(#123):feature`", "feat(#123):feature"},
+		{"`top level quotes should be removed`", "top level quotes should be removed"},
+		{"`aidy pr` works incorrectly", "`aidy pr` works incorrectly"},
+		{"789", "789"},
+		{"`aidy ci` and `aidy issue` commands", "`aidy ci` and `aidy issue` commands"},
+		{"`aidy ci` and `aidy issue`", "`aidy ci` and `aidy issue`"},
+		{"", ""},
+	}
+	for _, test := range tests {
+		assert.Equal(t, test.expected, healQuotes(test.input))
+	}
 }
 
 func TestCommit(t *testing.T) {
@@ -153,7 +171,7 @@ func TestHandleIssue(t *testing.T) {
 	require.NoError(t, err)
 	output := buf.String()
 	expected := "\ngh issue create --title \"Mock Issue Title for test input\" --body \"Mock Issue Body for test input\" --label \"bug,documentation,question\" --repo mock/remote"
-	assert.Equal(t, strings.TrimSpace(output), strings.TrimSpace(expected))
+	assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(output))
 }
 
 func TestHandleHelp(t *testing.T) {


### PR DESCRIPTION
This PR fixes the quote healing logic to preserve inner backticks and only remove top-level quotes when they're properly matched.

Closes #108