### PR TITLE
fix(#116): ensure .gitignore is created in git root directory

### DIFF
--- a/git/mockgit.go
+++ b/git/mockgit.go
@@ -41,3 +41,51 @@ func (r *MockGit) Installed() (bool, error) {
 func (r *MockGit) Root() (string, error) {
 	return "/dev/null", nil
 }
+
+type MockGitWithDir struct {
+	dir string
+}
+
+func NewMockGitWithDir(dir string) *MockGitWithDir {
+	return &MockGitWithDir{dir: dir}
+}
+
+func (m *MockGitWithDir) GetBaseBranchName() (string, error) {
+	return "main", nil
+}
+
+func (m *MockGitWithDir) AppendToCommit() error {
+	return nil
+}
+
+func (m *MockGitWithDir) GetBranchName() (string, error) {
+	return "41_working_branch", nil
+}
+
+func (m *MockGitWithDir) GetDiff() (string, error) {
+	return "mock-diff", nil
+}
+
+func (m *MockGitWithDir) GetCurrentDiff() (string, error) {
+	return "current-mock-diff", nil
+}
+
+func (m *MockGitWithDir) CommitChanges(messages ...string) error {
+	return nil
+}
+
+func (m *MockGitWithDir) GetCurrentCommitMessage() (string, error) {
+	return "feat(#42): current commit message", nil
+}
+
+func (m *MockGitWithDir) Remotes() ([]string, error) {
+	return []string{"https://github.com/volodya-lombrozo/aidy.git", "https://github.com/volodya-lombrozo/forked-aidy.git"}, nil
+}
+
+func (m *MockGitWithDir) Installed() (bool, error) {
+	return true, nil
+}
+
+func (m *MockGitWithDir) Root() (string, error) {
+	return m.dir, nil
+}

--- a/git/realgit.go
+++ b/git/realgit.go
@@ -175,5 +175,5 @@ func (r *RealGit) Root() (string, error) {
 		log.Printf("Can't find git root directory, '%v'", err)
 		return out, err
 	}
-	return out, nil
+	return strings.TrimSpace(out), nil
 }

--- a/main.go
+++ b/main.go
@@ -24,13 +24,12 @@ func main() {
 
 	command := os.Args[1]
 	shell := &executor.RealExecutor{}
-
-	gitcache, err := cache.NewGitCache(".aidy/cache.js")
+	gitService := git.NewRealGit(shell)
+	gitcache, err := cache.NewGitCache(".aidy/cache.js", gitService)
 	if err != nil {
 		log.Fatalf("Can't open cache %v", err)
 	}
 	ch := cache.NewAidyCache(gitcache)
-	gitService := git.NewRealGit(shell)
 	yamlConfig := readConfiguration(gitService)
 	githubKey, err := yamlConfig.GetGithubAPIKey()
 	if err != nil {


### PR DESCRIPTION
This PR modifies `aidy` to always place `.gitignore` in the root Git directory instead of the current working directory, preventing multiple `.gitignore` files in subfolders.

Closes #116