### PR TITLE
refactor(#44): consolidate git commands under Git interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Aidy is a command-line tool that generates GitHub pull request commands with AI-generated titles and body messages.
 
+[GitHub flow](https://docs.github.com/en/get-started/using-github/github-flow)
+
 ## Features
 
 - Generate concise and structured pull request titles and bodies using OpenAI.

--- a/git/git.go
+++ b/git/git.go
@@ -11,4 +11,7 @@ type Git interface {
 	Remotes() ([]string, error)
 	Installed() (bool, error)
 	Root() (string, error)
+	Reset(ref string) error
+	AddAll() error
+	Amend(message string) error
 }

--- a/git/mockgit.go
+++ b/git/mockgit.go
@@ -1,9 +1,42 @@
 package git
 
-type MockGit struct{}
+import (
+	"github.com/volodya-lombrozo/aidy/executor"
+)
+
+type MockGit struct {
+	Shell executor.Executor
+}
+
+func (m *MockGit) Amend(message string) error {
+	if m.Shell != nil {
+		if _, err := m.Shell.RunCommand("git commit --amend -m " + message); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *MockGit) AddAll() error {
+	if m.Shell != nil {
+		if _, err := m.Shell.RunCommand("git add --all"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
 func (m *MockGit) GetBaseBranchName() (string, error) {
 	return "main", nil
+}
+
+func (m *MockGit) Reset(ref string) error {
+	if m.Shell != nil {
+		if _, err := m.Shell.RunCommand("git reset --soft", ref); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (m *MockGit) AppendToCommit() error {
@@ -46,8 +79,12 @@ type MockGitWithDir struct {
 	dir string
 }
 
-func NewMockGitWithDir(dir string) *MockGitWithDir {
+func NewMockGitWithDir(dir string) Git {
 	return &MockGitWithDir{dir: dir}
+}
+
+func (m *MockGitWithDir) Reset(ref string) error {
+	return nil
 }
 
 func (m *MockGitWithDir) GetBaseBranchName() (string, error) {
@@ -88,4 +125,12 @@ func (m *MockGitWithDir) Installed() (bool, error) {
 
 func (m *MockGitWithDir) Root() (string, error) {
 	return m.dir, nil
+}
+
+func (m *MockGitWithDir) AddAll() error {
+	return nil
+}
+
+func (m *MockGitWithDir) Amend(message string) error {
+	panic("unimplemented")
 }

--- a/git/realgit.go
+++ b/git/realgit.go
@@ -14,7 +14,14 @@ type RealGit struct {
 	shell executor.Executor
 }
 
-// NewRealGit creates a new RealGit instance. If no directory is provided, it uses the current working directory.
+func (r *RealGit) Amend(message string) error {
+	_, err := r.shell.RunCommandInDir(r.dir, "git", "commit", "--amend", "-m", message)
+	if err != nil {
+		return fmt.Errorf("error amending commit: %w", err)
+	}
+	return nil
+}
+
 func NewRealGit(shell executor.Executor, dir ...string) *RealGit {
 	var directory string
 	if len(dir) > 0 && dir[0] != "" {
@@ -27,6 +34,14 @@ func NewRealGit(shell executor.Executor, dir ...string) *RealGit {
 		}
 	}
 	return &RealGit{dir: directory, shell: shell}
+}
+
+func (r *RealGit) Reset(ref string) error {
+	_, err := r.shell.RunCommandInDir(r.dir, "git", "reset", "--soft", ref)
+	if err != nil {
+		return fmt.Errorf("error resetting to %s: %w", ref, err)
+	}
+	return nil
 }
 
 func (r *RealGit) CommitChanges(messages ...string) error {
@@ -176,4 +191,12 @@ func (r *RealGit) Root() (string, error) {
 		return out, err
 	}
 	return strings.TrimSpace(out), nil
+}
+
+func (r *RealGit) AddAll() error {
+	_, err := r.shell.RunCommandInDir(r.dir, "git", "add", "--all")
+	if err != nil {
+		return fmt.Errorf("error adding all changes: %w", err)
+	}
+	return nil
 }

--- a/main.go
+++ b/main.go
@@ -21,7 +21,6 @@ func main() {
 	if len(os.Args) < 2 {
 		log.Fatal("Error: No command provided. Use 'aidy help' for usage.")
 	}
-
 	command := os.Args[1]
 	shell := &executor.RealExecutor{}
 	gitService := git.NewRealGit(shell)
@@ -235,7 +234,7 @@ func squash(gitService git.Git, shell executor.Executor, aiService ai.AI) {
 	if err != nil {
 		log.Fatalf("Error determining base branch: %v", err)
 	}
-	_, resetErr := shell.RunCommand("git", "reset", "--soft", "refs/heads/"+baseBranch)
+	resetErr := gitService.Reset("refs/heads/" + baseBranch)
 	if resetErr != nil {
 		log.Fatalf("Error executing git reset: %v", err)
 	}
@@ -253,7 +252,7 @@ func commit(gitService git.Git, shell executor.Executor, noAI bool, aiService ai
 		if err != nil {
 			log.Fatalf("Error getting branch name: %v", err)
 		}
-		_, addErr := shell.RunCommand("git", "add", "--all")
+		addErr := gitService.AddAll()
 		if addErr != nil {
 			log.Fatalf("Error adding git files: %v", err)
 		}
@@ -317,7 +316,7 @@ func heal(gitService git.Git, shell executor.Executor) {
 	}
 	re := regexp.MustCompile(`#\d+`)
 	newCommitMessage := re.ReplaceAllString(commitMessage, fmt.Sprintf("#%s", issueNumber))
-	_, err = shell.RunCommand("git", "commit", "--amend", "-m", newCommitMessage)
+	err = gitService.Amend(newCommitMessage)
 	if err != nil {
 		log.Fatalf("Error amending commit message: %v", err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -18,11 +18,11 @@ import (
 )
 
 func TestHeal(t *testing.T) {
-	mockGit := &git.MockGit{}
 	mockExecutor := &executor.MockExecutor{
 		Output: "",
 		Err:    nil,
 	}
+	mockGit := &git.MockGit{Shell: mockExecutor}
 
 	heal(mockGit, mockExecutor)
 
@@ -57,12 +57,12 @@ func TestCleanCache(t *testing.T) {
 }
 
 func TestSquash(t *testing.T) {
-	mockGit := &git.MockGit{}
 	mockAI := &ai.MockAI{}
 	mockExecutor := &executor.MockExecutor{
 		Output: "",
 		Err:    nil,
 	}
+	mockGit := &git.MockGit{Shell: mockExecutor}
 
 	squash(mockGit, mockExecutor, mockAI)
 
@@ -71,7 +71,6 @@ func TestSquash(t *testing.T) {
 		"git add --all",
 		"git commit --amend -m feat(#41): current commit message",
 	}
-
 	for i, expectedCommand := range expectedCommands {
 		if !strings.Contains(mockExecutor.Commands[i], expectedCommand) {
 			t.Errorf("Expected command '%s', got '%s'", expectedCommand, mockExecutor.Commands[i])
@@ -135,12 +134,12 @@ func TestHealQuotesParametrized(t *testing.T) {
 }
 
 func TestCommit(t *testing.T) {
-	mockGit := &git.MockGit{}
 	mockAI := &ai.MockAI{}
 	mockExecutor := &executor.MockExecutor{
 		Output: "",
 		Err:    nil,
 	}
+	mockGit := &git.MockGit{Shell: mockExecutor}
 
 	commit(mockGit, mockExecutor, false, mockAI)
 


### PR DESCRIPTION
This PR consolidates all `git` command executions under the `Git` interface, moving direct shell calls into the module for better consistency and maintainability.

Closes #44