### PR TITLE
test(#123): add tests for edit and run functionality of generated commands

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1,7 +1,9 @@
 package executor
 
 type Executor interface {
-	RunCommand(name string, args ...string) (string, error)
+	RunCommand(cmd string, args ...string) (string, error)
 
-	RunCommandInDir(dir string, name string, args ...string) (string, error)
+	RunCommandInDir(dir string, cmd string, args ...string) (string, error)
+
+	RunInteractively(cmd string, args ...string) (string, error)
 }

--- a/executor/mockexecutor.go
+++ b/executor/mockexecutor.go
@@ -8,14 +8,24 @@ type MockExecutor struct {
 	Commands []string
 }
 
-func (m *MockExecutor) RunCommand(name string, args ...string) (string, error) {
-	command := name + " " + strings.Join(args, " ")
+func NewMock() *MockExecutor {
+	return &MockExecutor{}
+}
+
+func (m *MockExecutor) RunInteractively(cmd string, args ...string) (string, error) {
+	command := cmd + " " + strings.Join(args, " ")
 	m.Commands = append(m.Commands, command)
 	return m.Output, m.Err
 }
 
-func (m *MockExecutor) RunCommandInDir(dir string, name string, args ...string) (string, error) {
-	command := "cd " + dir + " && " + name + " " + strings.Join(args, " ")
+func (m *MockExecutor) RunCommand(cmd string, args ...string) (string, error) {
+	command := cmd + " " + strings.Join(args, " ")
+	m.Commands = append(m.Commands, command)
+	return m.Output, m.Err
+}
+
+func (m *MockExecutor) RunCommandInDir(dir string, cmd string, args ...string) (string, error) {
+	command := "cd " + dir + " && " + cmd + " " + strings.Join(args, " ")
 	m.Commands = append(m.Commands, command)
 	return m.Output, m.Err
 }

--- a/executor/realexecutor.go
+++ b/executor/realexecutor.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -11,6 +12,23 @@ import (
 type RealExecutor struct{}
 
 const maxLogLength = 120
+
+func NewRealExecutor() Executor {
+	return &RealExecutor{}
+}
+
+func (r *RealExecutor) RunInteractively(cmd string, args ...string) (string, error) {
+	logShortf("Execute: \"%s\" with args: \"%v\"", cmd, args)
+	command := exec.Command(cmd, args...)
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	command.Stdin = os.Stdin
+	err := command.Run()
+	if err != nil {
+		return "", err
+	}
+	return "unimplemented", nil
+}
 
 func (r *RealExecutor) RunCommand(name string, args ...string) (string, error) {
 	logShortf("Execute: \"%s %s\"", name, strings.Join(args, " "))

--- a/executor/realexecutor_test.go
+++ b/executor/realexecutor_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestRealExecutor_RunCommand(t *testing.T) {
-	executor := &RealExecutor{}
+	executor := NewRealExecutor()
 
 	// Test the echo command
 	output, err := executor.RunCommand("echo", "Hello, World!")
@@ -36,7 +36,7 @@ func TestRealExecutor_RunCommandInDir(t *testing.T) {
 		}
 	}()
 
-	executor := &RealExecutor{}
+	executor := NewRealExecutor()
 	output, err := executor.RunCommandInDir(tempDir, "echo", "Hello, Directory!")
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)

--- a/git/realgit_test.go
+++ b/git/realgit_test.go
@@ -68,7 +68,7 @@ func TestRealGit_Reset(t *testing.T) {
 	repoDir, cleanup := setupTestRepo(t)
 	defer cleanup()
 
-	gitService := NewRealGit(&executor.RealExecutor{}, repoDir)
+	gitService := NewRealGit(executor.NewRealExecutor(), repoDir)
 
 	filePath := filepath.Join(repoDir, "resetfile.txt")
 	if err := os.WriteFile(filePath, []byte("Reset content"), 0644); err != nil {
@@ -108,7 +108,7 @@ func TestRealGit_Reset(t *testing.T) {
 func TestRealGitRoot(t *testing.T) {
 	repoDir, cleanup := setupTestRepo(t)
 	defer cleanup()
-	gitService := NewRealGit(&executor.RealExecutor{}, repoDir)
+	gitService := NewRealGit(executor.NewRealExecutor(), repoDir)
 
 	root, err := gitService.Root()
 
@@ -173,7 +173,7 @@ func TestRealGit_CommitChanges(t *testing.T) {
 		t.Fatalf("Error writing to file: %v", err)
 	}
 
-	gitService := NewRealGit(&executor.RealExecutor{}, repoDir)
+	gitService := NewRealGit(executor.NewRealExecutor(), repoDir)
 
 	// Commit the changes
 	err := gitService.CommitChanges()
@@ -239,7 +239,7 @@ func setupTestRepo(t *testing.T) (string, func()) {
 func TestRealGetBranchName(t *testing.T) {
 	dir, cleanup := setupTestRepo(t)
 	defer cleanup()
-	gitService := NewRealGit(&executor.RealExecutor{}, dir)
+	gitService := NewRealGit(executor.NewRealExecutor(), dir)
 	branchName, err := gitService.GetBranchName()
 	if err != nil {
 		t.Fatalf("Error getting branch name: %v", err)
@@ -252,7 +252,7 @@ func TestRealGetBranchName(t *testing.T) {
 func TestRealGetBaseBranchName(t *testing.T) {
 	repoDir, cleanup := setupTestRepo(t)
 	defer cleanup()
-	gitService := NewRealGit(&executor.RealExecutor{}, repoDir)
+	gitService := NewRealGit(executor.NewRealExecutor(), repoDir)
 	baseBranch, err := gitService.GetBaseBranchName()
 	if err != nil {
 		t.Fatalf("Error getting base branch name: %v", err)
@@ -282,7 +282,7 @@ func TestRealGetDiff(t *testing.T) {
 	if err := os.WriteFile(filePath, []byte("Hello, Git!"), 0644); err != nil {
 		t.Fatalf("Error writing to file: %v", err)
 	}
-	gitService := NewRealGit(&executor.RealExecutor{}, repoDir)
+	gitService := NewRealGit(executor.NewRealExecutor(), repoDir)
 	diff, err := gitService.GetDiff()
 	if err != nil {
 		t.Fatalf("Error getting diff: %v", err)
@@ -312,7 +312,7 @@ func TestRealGetCurrentDiff(t *testing.T) {
 	if err := os.WriteFile(filePath, []byte("Hello, Git!"), 0644); err != nil {
 		t.Fatalf("Error writing to file: %v", err)
 	}
-	gitService := NewRealGit(&executor.RealExecutor{}, repoDir)
+	gitService := NewRealGit(executor.NewRealExecutor(), repoDir)
 	diff, err := gitService.GetDiff()
 	if err != nil {
 		t.Fatalf("Error getting diff: %v", err)
@@ -341,7 +341,7 @@ func TestRealGetCurrentCommitMessage(t *testing.T) {
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("Error running command: %v", err)
 	}
-	gitService := NewRealGit(&executor.RealExecutor{}, repoDir)
+	gitService := NewRealGit(executor.NewRealExecutor(), repoDir)
 	message, err := gitService.GetCurrentCommitMessage()
 	if err != nil {
 		t.Fatalf("Error getting current commit message: %v", err)
@@ -354,7 +354,7 @@ func TestRealGetCurrentCommitMessage(t *testing.T) {
 func TestRealGitInstalled(t *testing.T) {
 	repoDir, cleanup := setupTestRepo(t)
 	defer cleanup()
-	gitService := NewRealGit(&executor.RealExecutor{}, repoDir)
+	gitService := NewRealGit(executor.NewRealExecutor(), repoDir)
 
 	installed, err := gitService.Installed()
 

--- a/main.go
+++ b/main.go
@@ -23,9 +23,9 @@ func main() {
 		log.Fatal("Error: No command provided. Use 'aidy help' for usage.")
 	}
 	command := os.Args[1]
-	shell := &executor.RealExecutor{}
+	shell := executor.NewRealExecutor()
 	gitService := git.NewRealGit(shell)
-	out := output.NewEditor()
+	out := output.NewEditor(shell)
 	gitcache, err := cache.NewGitCache(".aidy/cache.js", gitService)
 	if err != nil {
 		log.Fatalf("Can't open cache %v", err)

--- a/output/editor_test.go
+++ b/output/editor_test.go
@@ -1,0 +1,114 @@
+package output
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/volodya-lombrozo/aidy/executor"
+)
+
+func TestEditor_Print(t *testing.T) {
+	shell := executor.NewMock()
+	editor := NewEditor(shell)
+	oldStdin := os.Stdin
+	defer func() { os.Stdin = oldStdin }()
+	r, w, _ := os.Pipe()
+	os.Stdin = r
+	if _, err := io.WriteString(w, "r\n"); err != nil {
+		t.Errorf("failed to write to pipe: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Errorf("failed to close write pipe: %v", err)
+	}
+
+	command := "echo 'Hello, World!'"
+
+	editor.Print(command)
+
+	assert.Len(t, shell.Commands, 1, "expected 1 command to be run")
+	assert.Equal(t, "echo 'Hello, World!'", shell.Commands[0], "expected command to match")
+}
+
+func TestEditor_Print_DefaultOption(t *testing.T) {
+	shell := executor.NewMock()
+	editor := NewEditor(shell)
+	oldStdin := os.Stdin
+	defer func() { os.Stdin = oldStdin }()
+	r, w, _ := os.Pipe()
+	os.Stdin = r
+	if _, err := io.WriteString(w, "r\n"); err != nil {
+		t.Errorf("failed to write to pipe: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Errorf("failed to close write pipe: %v", err)
+	}
+	command := "echo 'Hello, World!'"
+
+	editor.Print(command)
+
+	assert.Len(t, shell.Commands, 1, "expected 1 command to be run")
+	assert.Equal(t, "echo 'Hello, World!'", shell.Commands[0], "expected command to match")
+}
+
+func TestEditor_Print_PrintOption(t *testing.T) {
+	shell := executor.NewMock()
+	editor := NewEditor(shell)
+	oldStdin := os.Stdin
+	defer func() { os.Stdin = oldStdin }()
+	r, w, _ := os.Pipe()
+	os.Stdin = r
+	if _, err := io.WriteString(w, "p\n"); err != nil {
+		t.Errorf("failed to write to pipe: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Errorf("failed to close write pipe: %v", err)
+	}
+	command := "echo 'Hello, World!'"
+
+	editor.Print(command)
+
+	assert.Len(t, shell.Commands, 0, "expected no command to be run")
+}
+
+func TestEditor_Print_CancelOption(t *testing.T) {
+	shell := executor.NewMock()
+	editor := NewEditor(shell)
+	oldStdin := os.Stdin
+	defer func() { os.Stdin = oldStdin }()
+	r, w, _ := os.Pipe()
+	os.Stdin = r
+	if _, err := io.WriteString(w, "c\n"); err != nil {
+		t.Errorf("failed to write to pipe: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Errorf("failed to close write pipe: %v", err)
+	}
+	command := "echo 'Hello, World!'"
+
+	editor.Print(command)
+
+	assert.Len(t, shell.Commands, 0, "expected no command to be run")
+}
+
+func TestEditor_Print_EditOption(t *testing.T) {
+	shell := executor.NewMock()
+	editor := NewEditor(shell)
+	oldStdin := os.Stdin
+	defer func() { os.Stdin = oldStdin }()
+	r, w, _ := os.Pipe()
+	os.Stdin = r
+	if _, err := io.WriteString(w, "e\n"); err != nil {
+		t.Errorf("failed to write to pipe: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Errorf("failed to close write pipe: %v", err)
+	}
+
+	command := "echo 'Hello, World!'"
+	editor.Print(command)
+
+	assert.Len(t, shell.Commands, 2, "expected 2 commands to be run")
+	assert.Equal(t, command, shell.Commands[1], "expected edited command to match")
+}


### PR DESCRIPTION
This PR adds comprehensive tests for the `editor` output functionality, covering all user interaction options (`run`, `print`, `cancel`, `edit`) and ensures proper command execution behavior.

Closes #123