### PR TITLE
ci(#135): update golangci-lint-action to v8 and version to 2.1.0

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,6 +22,6 @@ jobs:
         with:
           go-version: stable
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.0
+          version: v2.1.0


### PR DESCRIPTION
Updates `golangci-lint-action` from `v7` to `v8` and the linter version to `v2.1.0`.

Closes #135