### PR TITLE
fix(#142): show help for unrecognized commands

### DIFF
--- a/main.go
+++ b/main.go
@@ -125,7 +125,9 @@ func main() {
 	case "diff":
 		printDiff(gitService)
 	default:
-		log.Fatalf("Error: Unknown command '%s'. Use 'aidy help' for usage.\n", command)
+		log.Printf("Error: Unknown command '%s'.\n", command)
+		help()
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
Improves UX by showing `help` output when an unknown command is entered, instead of just an error message.

Closes #142