### PR TITLE
feat(#144): improve error handling for push failures in PR creation

### DIFF
--- a/main.go
+++ b/main.go
@@ -104,7 +104,7 @@ func main() {
 	case "pr", "pull-request":
 		pull_request(gitService, aiService, gh, ch, out)
 	case "h", "heal":
-		heal(gitService, shell)
+		heal(gitService)
 	case "ci", "commit":
 		noAI := len(os.Args) > 2 && os.Args[2] == "-n"
 		commit(gitService, shell, noAI, aiService)
@@ -228,7 +228,10 @@ func issue(userInput string, aiService ai.AI, gh github.Github, ch cache.AidyCac
 		cmd = fmt.Sprintf("\n%s", escapeBackticks(fmt.Sprintf("gh issue create --title \"%s\" --body \"%s\"", healQuotes(title), healQuotes(body))))
 	}
 	cmd = fmt.Sprintf("%s%s\n", cmd, repo)
-	out.Print(cmd)
+    err = out.Print(cmd)
+    if err != nil {
+        log.Fatalf("Error during making an issue: %v", err)
+    }
 }
 
 func squash(gitService git.Git, shell executor.Executor, aiService ai.AI) {
@@ -271,7 +274,7 @@ func commit(gitService git.Git, shell executor.Executor, noAI bool, aiService ai
 			log.Fatalf("Error committing changes: %v", err)
 		}
 	}
-	heal(gitService, shell)
+	heal(gitService)
 }
 
 func pull_request(gitService git.Git, aiService ai.AI, gh github.Github, ch cache.AidyCache, out output.Output) {
@@ -304,10 +307,13 @@ func pull_request(gitService git.Git, aiService ai.AI, gh github.Github, ch cach
 	prtitle := healPRTitle(healQuotes(title), nissue)
 	prbody := healPRBody(healQuotes(body), nissue)
 	cmd := escapeBackticks(fmt.Sprintf("gh pr create --title \"%s\" --body \"%s\"%s", prtitle, prbody, repo))
-	out.Print(cmd)
+	err = out.Print(cmd)
+	if err != nil {
+		log.Fatalf("Error during making a pull-request: %v", err)
+	}
 }
 
-func heal(gitService git.Git, shell executor.Executor) {
+func heal(gitService git.Git) {
 	branchName, err := gitService.GetBranchName()
 	if err != nil {
 		log.Fatalf("Error getting branch name: %v", err)

--- a/main_test.go
+++ b/main_test.go
@@ -26,7 +26,7 @@ func TestHeal(t *testing.T) {
 	}
 	mockGit := &git.MockGit{Shell: mockExecutor}
 
-	heal(mockGit, mockExecutor)
+	heal(mockGit)
 
 	expectedCommands := []string{
 		"git commit --amend -m feat(#41): current commit message",

--- a/output/output_test.go
+++ b/output/output_test.go
@@ -79,28 +79,26 @@ func TestFindEditor(t *testing.T) {
 
 func TestMockOutput(t *testing.T) {
 	mock := NewMock()
-
-	// Test capturing a single command
-	mock.Print("command1")
+	_ = mock.Print("command1")
 	require.Equal(t, "command1", mock.Last(), "Last command should be 'command1'")
 
-	// Test capturing multiple commands
-	mock.Print("command2")
+	_ = mock.Print("command2")
 	require.Equal(t, "command2", mock.Last(), "Last command should be 'command2'")
 
-	// Test capturing another command
-	mock.Print("command3")
+	_ = mock.Print("command3")
 	require.Equal(t, "command3", mock.Last(), "Last command should be 'command3'")
-
-	// Test panic when no commands are captured
-	defer func() {
-		if r := recover(); r == nil {
-			t.Errorf("Expected panic when no commands are captured")
-		}
-	}()
-	emptyMock := NewMock()
-	emptyMock.Last()
 }
+
+func TestMockOutput_Panics_WhenNoCommands(t *testing.T) {
+    mock := NewMock()
+    defer func() {
+        if r := recover(); r == nil {
+            t.Errorf("Expected panic when no commands are captured")
+        }
+    }()
+    mock.Last()
+}
+
 func TestCleanQoutes(t *testing.T) {
 	tests := []struct {
 		input    []string
@@ -127,15 +125,12 @@ func TestPrinter_Print(t *testing.T) {
 	os.Stdout = w
 	printer := NewPrinter()
 
-	printer.Print("hello")
-
-	if err := w.Close(); err != nil {
-		t.Errorf("failed to close write pipe: %v", err)
-	}
+	_ = printer.Print("hello")
+    err := w.Close();
+    require.NoError(t, err, "failed to close write pipe")
 	var buf bytes.Buffer
-	if _, err := io.Copy(&buf, r); err != nil {
-		t.Errorf("failed to copy data: %v", err)
-	}
+    _, err = io.Copy(&buf, r);
+    require.NoError(t, err, "failed to copy data")
 	os.Stdout = originalStdout
 	expected := "hello\n"
 	require.Equal(t, expected, buf.String(), "Output should match expected value")


### PR DESCRIPTION
Improves error handling in command execution by returning errors instead of panicking and adds proper error propagation for `output.Print()` operations.

Closes #144