### PR TITLE
feat(#147): improve commit message format for no-AI mode

### DIFF
--- a/ai/mockai_test.go
+++ b/ai/mockai_test.go
@@ -1,31 +1,44 @@
 package ai
 
 import (
-	"github.com/stretchr/testify/assert"
+	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+const diff = `
+diff --git a/ai/mockai.go b/ai/mockai.go
+index 97c5ff0..2eea6a0 100644
+--- a/ai/mockai.go
++++ b/ai/mockai.go
+@@ -3 +3,4 @@ package ai
+-import "fmt"
++import (
++       "fmt"
++       "strings"
++)
+`
 
 func TestMockGenerateCommitMessage(t *testing.T) {
 	mockAI := &MockAI{}
-	diff := "some changes"
-	branchName := "100"
-	expected := "Mock Commit Message for " + diff + " and branch " + branchName
-	msg, err := mockAI.CommitMessage(branchName, diff)
-	if err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-	if msg != expected {
-		t.Fatalf("Expected '%s', got '%s'", expected, msg)
-	}
+	issue := "100"
+	expected := fmt.Sprintf("feat(#%s): %s", issue, "changed files: ai/mockai.go")
+
+	msg, err := mockAI.CommitMessage(issue, diff)
+
+	require.NoError(t, err, "Expected no error")
+	assert.Equal(t, expected, msg, "Expected commit message to match")
 }
 
 func TestMockGenerateLabels(t *testing.T) {
 	mockAI := &MockAI{}
 	labels := []string{"bug", "feature"}
+
 	actual, err := mockAI.IssueLabels("issue", labels)
-	if err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
+
+	require.NoError(t, err, "Expected no error")
 	assert.Equal(t, labels, actual)
 }
 
@@ -35,12 +48,9 @@ func TestMockGenerateTitle(t *testing.T) {
 	expected := "'Mock Title for " + branchName + "'"
 
 	title, err := mockAI.PrTitle(branchName, "diff", "issue", "summary")
-	if err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-	if title != expected {
-		t.Fatalf("Expected '%s', got '%s'", expected, title)
-	}
+
+	require.NoError(t, err, "Expected no error")
+	assert.Equal(t, expected, title, "Expected title to match")
 }
 
 func TestMockGenerateIssueTitle(t *testing.T) {
@@ -49,12 +59,9 @@ func TestMockGenerateIssueTitle(t *testing.T) {
 	expected := "'Mock Issue Title for " + userInput + "'"
 
 	title, err := mockAI.IssueTitle(userInput, "summary")
-	if err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-	if title != expected {
-		t.Fatalf("Expected '%s', got '%s'", expected, title)
-	}
+
+	require.NoError(t, err, "Expected no error")
+	assert.Equal(t, expected, title, "Expected issue title to match")
 }
 
 func TestMockGenerateIssueBody(t *testing.T) {
@@ -63,12 +70,9 @@ func TestMockGenerateIssueBody(t *testing.T) {
 	expected := "Mock Issue Body for " + userInput
 
 	body, err := mockAI.IssueBody(userInput, "summary")
-	if err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-	if body != expected {
-		t.Fatalf("Expected '%s', got '%s'", expected, body)
-	}
+
+	require.NoError(t, err, "Expected no error")
+	assert.Equal(t, expected, body, "Expected issue body to match")
 }
 
 func TestMockGenerateBody(t *testing.T) {
@@ -77,10 +81,7 @@ func TestMockGenerateBody(t *testing.T) {
 	expected := "Mock Body for " + branchName
 
 	body, err := mockAI.PrBody(branchName, "diff", "issue", "summary")
-	if err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-	if body != expected {
-		t.Fatalf("Expected '%s', got '%s'", expected, body)
-	}
+
+	require.NoError(t, err, "Expected no error")
+	assert.Equal(t, expected, body, "Expected body to match")
 }

--- a/git/realgit.go
+++ b/git/realgit.go
@@ -50,20 +50,19 @@ func (r *RealGit) CommitChanges(messages ...string) error {
 		return fmt.Errorf("error adding changes: %w", err)
 	}
 
-	changedFiles, err := r.shell.RunCommandInDir(r.dir, "git", "diff", "--name-only", "--cached")
+	changed, err := r.shell.RunCommandInDir(r.dir, "git", "diff", "--name-only", "--cached")
 	if err != nil {
 		return fmt.Errorf("error getting changed files: %w", err)
 	}
 
-	var commitMessage string
+	var msg string
 	if len(messages) > 0 {
-		commitMessage = messages[0]
+		msg = messages[0]
 	} else {
-		commitMessage = strings.TrimSpace("Committing changes to the following files:\n" + changedFiles)
+		msg = strings.TrimSpace("Committing changes to the following files:\n" + changed)
 	}
 
-	_, err = r.shell.RunCommandInDir(r.dir, "git", "commit", "-m", commitMessage)
-
+	_, err = r.shell.RunCommandInDir(r.dir, "git", "commit", "-m", msg)
 	if err != nil {
 		return fmt.Errorf("error committing changes: %w", err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -53,7 +53,7 @@ func TestCleanCache(t *testing.T) {
 	err = os.Chdir(tempDir)
 	require.NoError(t, err, "Failed to change working directory")
 
-	cleanCache()
+	clean()
 
 	_, err = os.Stat(aidyDir)
 	assert.True(t, os.IsNotExist(err), ".aidy directory should be removed")
@@ -143,7 +143,7 @@ func TestSquash(t *testing.T) {
 	}
 	mockGit := &git.MockGit{Shell: mockExecutor}
 
-	squash(mockGit, mockExecutor, mockAI)
+	squash(mockGit, mockAI)
 
 	expectedCommands := []string{
 		"git reset --soft refs/heads/main",
@@ -207,7 +207,7 @@ func TestCommit(t *testing.T) {
 	}
 	mockGit := &git.MockGit{Shell: mockExecutor}
 
-	commit(mockGit, mockExecutor, false, mockAI)
+	commit(mockGit, mockAI)
 
 	expectedCommands := []string{
 		"git add --all",
@@ -288,7 +288,7 @@ func TestExtractIssueNumber(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		result := extractIssueNumber(test.branchName)
+		result := inumber(test.branchName)
 		if result != test.expected {
 			t.Errorf("For branch name '%s', expected '%s', got '%s'", test.branchName, test.expected, result)
 		}


### PR DESCRIPTION
This PR improves the commit message format for `aidy ci -n` to follow the same standard format as AI-generated messages, providing more meaningful content than just file lists.

Closes #147