### PR TITLE
feat(#120): Add release command with version tagging and release notes

### DIFF
--- a/ai/ai.go
+++ b/ai/ai.go
@@ -11,6 +11,7 @@ type AI interface {
 	CommitMessage(number string, diff string) (string, error)
 	Summary(readme string) (string, error)
 	SuggestBranch(descr string) (string, error)
+	ReleaseNotes(changes string) (string, error)
 }
 
 func TrimPrompt(prompt string) string {

--- a/ai/deepseek.go
+++ b/ai/deepseek.go
@@ -46,6 +46,11 @@ func NewDeepSeekAI(apiKey string, summary bool) *DeepSeekAI {
 	}
 }
 
+func (d *DeepSeekAI) ReleaseNotes(changes string) (string, error) {
+	prompt := fmt.Sprintf(ReleaseNotesPrompt, changes)
+	return d.sendPrompt("You are a helpful assistant generating GitHub release notes.", prompt, "")
+}
+
 func (d *DeepSeekAI) PrTitle(number, diff, issue, summary string) (string, error) {
 	prompt := fmt.Sprintf(GenerateTitlePrompt, diff, issue, number, number)
 	return d.sendPrompt("You are a helpful assistant generating Git commit titles.", prompt, summary)

--- a/ai/mockai.go
+++ b/ai/mockai.go
@@ -17,6 +17,13 @@ func NewFailedMockAI() AI {
 	return &MockAI{fail: true}
 }
 
+func (m *MockAI) ReleaseNotes(changes string) (string, error) {
+	if m.fail {
+		return "", fmt.Errorf("failed to generate release notes")
+	}
+	return fmt.Sprintf("Mock Release Notes\n\n%s", changes), nil
+}
+
 func (m *MockAI) PrTitle(branchName string, diff string, issue string, summary string) (string, error) {
 	return "'Mock Title for " + branchName + "'", nil
 }

--- a/ai/openai.go
+++ b/ai/openai.go
@@ -25,6 +25,11 @@ func NewOpenAI(apiKey, model string, temperature float32, summary bool) *MyOpenA
 	}
 }
 
+func (o *MyOpenAI) ReleaseNotes(changes string) (string, error) {
+	prompt := fmt.Sprintf(ReleaseNotesPrompt, changes)
+	return o.send(prompt, "")
+}
+
 func (o *MyOpenAI) PrTitle(number, diff, issue, summary string) (string, error) {
 	prompt := fmt.Sprintf(GenerateTitlePrompt, diff, issue, number, number)
 	return o.send(prompt, summary)
@@ -76,6 +81,10 @@ func (o *MyOpenAI) SuggestBranch(descr string) (string, error) {
 	return o.send(prompt, "")
 }
 
+// send sends a prompt to the OpenAI API and returns the response.
+// Parameters:
+// - prompt: The prompt to send.
+// - summary: The project summary to append to the prompt (if applicable).
 func (o *MyOpenAI) send(prompt, summary string) (string, error) {
 	content := prompt
 	if o.summary {

--- a/ai/prompts.go
+++ b/ai/prompts.go
@@ -160,4 +160,23 @@ The branch name should:
 
 Reply only with the branch name — no explanations, comments, or extra formatting.
 `
+	ReleaseNotesPrompt = `You are an expert software engineer responsible for preparing professional release notes for a new software version.
+
+Generate clear, concise release notes based on the list of commit messages provided below.
+
+<commits>
+%s
+</commits>
+
+Your task:
+- Summarize the changes introduced in this release.
+- Group related changes together where appropriate (e.g., features, bug fixes, performance improvements).
+- Use bullet points for each notable change.
+- Write in a formal, professional tone suitable for end users and developers.
+- Avoid duplicating similar messages.
+- Do not include commit hashes.
+- Mention issue numbers (e.g., #42) when available in commit messages.
+- Do not list individual commits — summarize them meaningfully.
+
+Output only the release notes — no explanations, comments, or extra formatting.`
 )

--- a/git/git.go
+++ b/git/git.go
@@ -15,4 +15,8 @@ type Git interface {
 	AddAll() error
 	Amend(message string) error
 	Checkout(branch string) error
+	Tags() ([]string, error)
+	AddTag(tag string, message string) error
+	AddTagCommand(tag string, message string) string
+	Log(since string) ([]string, error)
 }

--- a/git/mockgit.go
+++ b/git/mockgit.go
@@ -1,11 +1,44 @@
 package git
 
 import (
+	"fmt"
+
 	"github.com/volodya-lombrozo/aidy/executor"
 )
 
 type MockGit struct {
 	Shell executor.Executor
+}
+
+func (m *MockGit) Log(since string) ([]string, error) {
+	if m.Shell != nil {
+		if _, err := m.Shell.RunCommand(fmt.Sprintf("git log %s..HEAD --pretty=format:%%s", since)); err != nil {
+			return nil, err
+		}
+	}
+	return []string{"ci(#120): Update CI to use Ubuntu 24.04 and add .aidy to gitignore", "chore(deps): update dependency ruby to v3.4.3 (#117)"}, nil
+}
+
+func (m *MockGit) AddTag(tag string, message string) error {
+	if m.Shell != nil {
+		if _, err := m.Shell.RunCommand(fmt.Sprintf("git tag -a %s -m %s", tag, message)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *MockGit) AddTagCommand(tag string, message string) string {
+	return fmt.Sprintf("git tag -a \"%s\" -m \"%s\"", tag, message)
+}
+
+func (m *MockGit) Tags() ([]string, error) {
+	if m.Shell != nil {
+		if _, err := m.Shell.RunCommand("git tag"); err != nil {
+			return nil, err
+		}
+	}
+	return []string{"v1.0", "v2.0"}, nil
 }
 
 func (m *MockGit) Amend(message string) error {
@@ -92,6 +125,21 @@ func NewMockGitWithDir(dir string) Git {
 	return &MockGitWithDir{dir: dir}
 }
 
+func (m *MockGitWithDir) AddTagCommand(tag string, message string) string {
+	return fmt.Sprintf("git tag -a \"%s\" -m \"%s\"", tag, message)
+}
+
+func (m *MockGitWithDir) Log(since string) ([]string, error) {
+	return []string{"ci(#120): Update CI to use Ubuntu 24.04 and add .aidy to gitignore", "chore(deps): update dependency ruby to v3.4.3 (#117)"}, nil
+}
+
+func (m *MockGitWithDir) AddTag(tag string, message string) error {
+	return nil
+}
+
+func (m *MockGitWithDir) Tags() ([]string, error) {
+	return []string{"v1.0", "v2.0"}, nil
+}
 func (m *MockGitWithDir) Reset(ref string) error {
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,8 @@ require (
 )
 
 require (
+	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/mod v0.24.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Masterminds/semver/v3 v3.3.1 h1:QtNSWtVZ3nBfk8mAOu/B6v7FMJ+NHTIgUPi7rj+4nv4=
+github.com/Masterminds/semver/v3 v3.3.1/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -16,6 +18,8 @@ github.com/sashabaranov/go-openai v1.40.0 h1:Peg9Iag5mUJtPW00aYatlsn97YML0iNULiL
 github.com/sashabaranov/go-openai v1.40.0/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+golang.org/x/mod v0.24.0 h1:ZfthKaKaT4NrhGVZHO1/WDTwGES4De8KtWO0SIbNJMU=
+golang.org/x/mod v0.24.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
This PR adds a new `aidy release` command that supports version tagging with AI-generated release notes, including automatic version bumping based on semantic versioning.

Closes #120