### PR TITLE
ci(#159): fetch all tags to fix release notes in goreleaser

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -17,6 +17,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Fetch all tags
+        run: git fetch --tags --force
       - name: Set up Go
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
This PR ensures release notes show tag messages instead of commit messages by fetching all tags before running `goreleaser`.

Closes #159