### PR TITLE
feat(#155): add an option for 'release' command to specify target repo

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -21,6 +21,6 @@ type Git interface {
 	AddAll() error
 	Amend(message string) error
 	Checkout(branch string) error
-	Tags() ([]string, error)
+	Tags(repo string) ([]string, error)
 	Log(since string) ([]string, error)
 }

--- a/git/mock.go
+++ b/git/mock.go
@@ -42,8 +42,8 @@ func (m *mock) Log(since string) ([]string, error) {
 	}, nil
 }
 
-func (m *mock) Tags() ([]string, error) {
-	if _, err := m.shell.RunCommand("git tag"); err != nil {
+func (m *mock) Tags(repo string) ([]string, error) {
+	if _, err := m.Run("fetch", repo, "--tags"); err != nil {
 		return nil, err
 	}
 	return []string{"v1.0", "v2.0"}, nil

--- a/git/mock_test.go
+++ b/git/mock_test.go
@@ -207,7 +207,7 @@ func TestMock_Checkout(t *testing.T) {
 func TestMock_Tags(t *testing.T) {
 	git := NewMock()
 
-	output, err := git.Tags()
+	output, err := git.Tags("does-not-matter")
 
 	require.NoError(t, err)
 	assert.Equal(t, []string{"v1.0", "v2.0"}, output)

--- a/git/real.go
+++ b/git/real.go
@@ -188,8 +188,13 @@ func (r *real) Checkout(branch string) error {
 	return nil
 }
 
-func (r *real) Tags() ([]string, error) {
-	_, err := r.Run("fetch", "--tags")
+func (r *real) Tags(repo string) ([]string, error) {
+	var err error
+	if repo == "" {
+		_, err = r.Run("fetch", "--tags")
+	} else {
+		_, err = r.Run("fetch", repo, "--tags")
+	}
 	if err != nil {
 		return nil, fmt.Errorf("error fetching tags: %w", err)
 	}

--- a/git/real_test.go
+++ b/git/real_test.go
@@ -60,7 +60,7 @@ func TestRealGit_Tags_Success(t *testing.T) {
 	}
 	gs := NewGit(shell)
 
-	tags, err := gs.Tags()
+	tags, err := gs.Tags("upstream")
 
 	require.NoError(t, err)
 	expectedTags := []string{"v1.0.0", "v1.1.0", "v2.1.0"}
@@ -73,7 +73,7 @@ func TestRealGit_Tags_FetchError(t *testing.T) {
 	}
 	gs := NewGit(shell)
 
-	tags, err := gs.Tags()
+	tags, err := gs.Tags("errepo")
 
 	require.Error(t, err)
 	assert.Nil(t, tags)
@@ -87,7 +87,7 @@ func TestRealGit_Tags_ListError(t *testing.T) {
 	}
 	gs := NewGit(shell)
 
-	tags, err := gs.Tags()
+	tags, err := gs.Tags("origin")
 
 	require.Error(t, err)
 	assert.Nil(t, tags)

--- a/main.go
+++ b/main.go
@@ -109,7 +109,13 @@ func main() {
 		if len(os.Args) < 3 {
 			log.Fatalf("Error: No release step provided. Use 'aidy help' for usage.")
 		}
-		err := release(os.Args[2], gs, brain, out)
+		var repo string
+		if len(os.Args) >= 4 {
+			repo = os.Args[3]
+		} else {
+			repo = ""
+		}
+		err := release(os.Args[2], repo, gs, brain, out)
 		if err != nil {
 			log.Fatalf("Error during release: %v", err)
 		}
@@ -152,8 +158,8 @@ func main() {
 	}
 }
 
-func release(step string, gs git.Git, brain ai.AI, out output.Output) error {
-	tags, err := gs.Tags()
+func release(step string, repo string, gs git.Git, brain ai.AI, out output.Output) error {
+	tags, err := gs.Tags(repo)
 	if err != nil {
 		return fmt.Errorf("failed to get tags: '%v'", err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -387,7 +387,7 @@ func TestRelease_Success(t *testing.T) {
 	nobrain := ai.NewMockAI()
 	out := output.NewMock()
 
-	err := release("minor", mgit, nobrain, out)
+	err := release("minor", "origin", mgit, nobrain, out)
 	assert.NoError(t, err, "expected no error during release")
 	expected := "git tag --cleanup=verbatim -a \"v2.1.0\" -m \""
 	assert.Contains(t, out.Last(), expected, "expected release command to be generated")
@@ -398,7 +398,7 @@ func TestReleaseNoTags(t *testing.T) {
 	mockAI := ai.NewMockAI()
 	out := output.NewMock()
 
-	err := release("", mockGit, mockAI, out)
+	err := release("", "origin", mockGit, mockAI, out)
 
 	assert.EqualError(t, err, "failed to update version: 'unknown version step: '''", "expected error when no tags are present")
 }
@@ -413,7 +413,7 @@ func TestReleaseTagFetchError(t *testing.T) {
 	nobrain := ai.NewMockAI()
 	out := output.NewMock()
 
-	err := release("patch", mgit, nobrain, out)
+	err := release("patch", "origin", mgit, nobrain, out)
 
 	assert.Error(t, err, "expected error when fetching tags fails")
 	assert.Contains(t, err.Error(), "failed to get tags", "expected error message about fetching tags")
@@ -424,7 +424,7 @@ func TestReleaseNotesGenerationError(t *testing.T) {
 	nobrain := ai.NewFailedMockAI()
 	out := output.NewMock()
 
-	err := release("major", mgit, nobrain, out)
+	err := release("major", "origin", mgit, nobrain, out)
 
 	assert.Error(t, err, "expected error when generating release notes fails")
 	assert.Contains(t, err.Error(), "failed to generate release notes", "expected error message about release notes generation")


### PR DESCRIPTION
Modifies `aidy release` to accept a repository parameter and fetch tags from the specified remote, with empty string falling back to default behavior.

Closes #155