### PR TITLE
test(#106): Add unit tests for config and diff commands

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -9,8 +9,8 @@ func newConfigCmd(ctx *Context) *cobra.Command {
 		Use:     "config",
 		Aliases: []string{"conf"},
 		Short:   "Print the current configuration",
-		Run: func(cmd *cobra.Command, args []string) {
-			ctx.Assistant.PrintConfig()
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return ctx.Assistant.PrintConfig()
 		},
 	}
 	return command

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -9,8 +9,8 @@ func newDiffCmd(ctx *Context) *cobra.Command {
 		Use:     "diff",
 		Aliases: []string{"df"},
 		Short:   "Print the current diff that will be used to generate the commit message",
-		Run: func(cmd *cobra.Command, args []string) {
-			ctx.Assistant.Diff()
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return ctx.Assistant.Diff()
 		},
 	}
 	return command

--- a/internal/aidy/aidy.go
+++ b/internal/aidy/aidy.go
@@ -2,7 +2,7 @@ package aidy
 
 type Aidy interface {
 	Release(interval string, repo string) error
-	PrintConfig()
+	PrintConfig() error
 	Commit()
 	Squash()
 	PullRequest()
@@ -10,6 +10,6 @@ type Aidy interface {
 	Heal()
 	Append()
 	Clean()
-	Diff()
+	Diff() error
 	StartIssue(number string) error
 }

--- a/internal/aidy/mock.go
+++ b/internal/aidy/mock.go
@@ -15,8 +15,9 @@ func (m *Mock) Release(interval string, repo string) error {
 	return nil
 }
 
-func (m *Mock) PrintConfig() {
+func (m *Mock) PrintConfig() error {
 	m.logs = append(m.logs, "PrintConfig called")
+	return nil
 }
 
 func (m *Mock) Commit() {
@@ -47,8 +48,9 @@ func (m *Mock) Clean() {
 	m.logs = append(m.logs, "Clean called")
 }
 
-func (m *Mock) Diff() {
+func (m *Mock) Diff() error {
 	m.logs = append(m.logs, "Diff called")
+	return nil
 }
 
 func (m *Mock) StartIssue(number string) error {

--- a/internal/aidy/mock_test.go
+++ b/internal/aidy/mock_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMockAidy_Release(t *testing.T) {
@@ -15,7 +16,8 @@ func TestMockAidy_Release(t *testing.T) {
 
 func TestMockAidy_PrintConfig(t *testing.T) {
 	aidy := NewMock()
-	aidy.PrintConfig()
+	err := aidy.PrintConfig()
+	require.NoError(t, err)
 	assert.Contains(t, aidy.Logs(), "PrintConfig called")
 }
 
@@ -63,7 +65,8 @@ func TestMockAidy_Clean(t *testing.T) {
 
 func TestMockAidy_Diff(t *testing.T) {
 	aidy := NewMock()
-	aidy.Diff()
+	err := aidy.Diff()
+	require.NoError(t, err)
 	assert.Contains(t, aidy.Logs(), "Diff called")
 }
 

--- a/internal/config/mock.go
+++ b/internal/config/mock.go
@@ -5,6 +5,7 @@ type MockConfig struct {
 	MockOpenai   string
 	MockGithub   string
 	MockModel    string
+	Error        error
 }
 
 func NewMock() *MockConfig {
@@ -17,17 +18,17 @@ func NewMock() *MockConfig {
 }
 
 func (m *MockConfig) DeepseekKey() (string, error) {
-	return m.MockDeepseek, nil
+	return m.MockDeepseek, m.Error
 }
 
 func (m *MockConfig) GithubKey() (string, error) {
-	return m.MockGithub, nil
+	return m.MockGithub, m.Error
 }
 
 func (m *MockConfig) Model() (string, error) {
-	return m.MockModel, nil
+	return m.MockModel, m.Error
 }
 
 func (m *MockConfig) OpenAiKey() (string, error) {
-	return m.MockOpenai, nil
+	return m.MockOpenai, m.Error
 }

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -173,6 +173,13 @@ func (m *Mock) Print(command string) error {
 	return nil
 }
 
+func (m *Mock) Captured() string {
+	if len(m.captured) == 0 {
+		return ""
+	}
+	return strings.Join(m.captured, "\n")
+}
+
 func (m *Mock) Last() string {
 	size := len(m.captured)
 	if size < 1 {


### PR DESCRIPTION
This PR significantly improves test coverage by adding comprehensive unit tests for the `config` and `diff` commands and their underlying implementations.

Related to #106