### PR TITLE
test(#106): Add comprehensive tests for cache, git, and github packages

### DIFF
--- a/internal/cache/aidy_cache.go
+++ b/internal/cache/aidy_cache.go
@@ -59,22 +59,30 @@ func (a *aidyCache) WithSummary(summary string, hash string) {
 }
 
 type mockAidyCache struct {
+	inner map[string]string
 }
 
 func NewMockAidyCache() AidyCache {
-	return &mockAidyCache{}
+	memory := make(map[string]string)
+	memory["target"] = "mock/remote"
+	memory["summary"] = "mock summary"
+	memory["summary-hash"] = "mock hash"
+	return &mockAidyCache{inner: memory}
 }
 
 func (a *mockAidyCache) Remote() string {
-	return "mock/remote"
+	return a.inner["target"]
 }
 
 func (a *mockAidyCache) WithRemote(remote string) {
+	a.inner["target"] = remote
 }
 
 func (a *mockAidyCache) Summary() (string, string) {
-	return "mock summary", "mock hash"
+	return a.inner["summary"], a.inner["summary-hash"]
 }
 
 func (a *mockAidyCache) WithSummary(summary, hash string) {
+	a.inner["summary"] = summary
+	a.inner["summary-hash"] = hash
 }

--- a/internal/cache/aidy_cache_test.go
+++ b/internal/cache/aidy_cache_test.go
@@ -66,9 +66,9 @@ func TestMockAidyCache_Remote(t *testing.T) {
 
 func TestMockAidyCache_WithRemote(t *testing.T) {
 	mc := NewMockAidyCache()
-	mc.WithRemote("new/remote") // Should not change anything
+	mc.WithRemote("new/remote")
 	remote := mc.Remote()
-	assert.Equal(t, "mock/remote", remote, "expected remote to be 'mock/remote'")
+	assert.Equal(t, "new/remote", remote, "expected remote to be 'mock/remote'")
 }
 
 func TestMockAidyCache_Summary(t *testing.T) {
@@ -82,8 +82,8 @@ func TestMockAidyCache_WithSummary(t *testing.T) {
 	mc := NewMockAidyCache()
 	mc.WithSummary("new summary", "new hash") // Should not change anything
 	summary, hash := mc.Summary()
-	assert.Equal(t, "mock summary", summary, "expected summary to be 'mock summary'")
-	assert.Equal(t, "mock hash", hash, "expected hash to be 'mock hash'")
+	assert.Equal(t, "new summary", summary, "expected summary to be 'new summary'")
+	assert.Equal(t, "new hash", hash, "expected hash to be 'new hash'")
 }
 
 func TestAidyCache_Remote(t *testing.T) {

--- a/internal/git/mock.go
+++ b/internal/git/mock.go
@@ -116,7 +116,7 @@ func (m *mock) CommitMessage() (string, error) {
 }
 
 func (r *mock) Remotes() ([]string, error) {
-	return []string{"https://github.com/volodya-lombrozo/aidy.git", "https://github.com/volodya-lombrozo/forked-aidy.git"}, nil
+	return []string{"https://github.com/volodya-lombrozo/aidy.git", "https://github.com/volodya-lombrozo/forked-aidy.git"}, r.err
 }
 
 func (r *mock) Installed() (bool, error) {

--- a/internal/github/real.go
+++ b/internal/github/real.go
@@ -36,12 +36,12 @@ type label struct {
 	Description string `json:"description"`
 }
 
-func NewGithub(baseURL string, gs git.Git, authToken string, ch cache.AidyCache) *github {
+func NewGithub(url string, gs git.Git, token string, ch cache.AidyCache) *github {
 	return &github{
 		client: &http.Client{},
-		url:    baseURL,
+		url:    url,
 		gs:     gs,
-		token:  authToken,
+		token:  token,
 		ch:     ch,
 	}
 }
@@ -79,7 +79,7 @@ func (r *github) Labels() ([]string, error) {
 		req.Header.Set("Authorization", "Bearer "+r.token)
 		resp, err := r.client.Do(req)
 		if err != nil {
-			return nil, fmt.Errorf("error fetching issue description: %w", err)
+			return nil, fmt.Errorf("error fetching issue labels: %w", err)
 		}
 		defer func() {
 			if err := resp.Body.Close(); err != nil {

--- a/internal/github/real_test.go
+++ b/internal/github/real_test.go
@@ -92,3 +92,117 @@ func TestRealGithub_Remotes(t *testing.T) {
 	expected := []string{"volodya-lombrozo/aidy", "volodya-lombrozo/forked-aidy"}
 	assert.Equal(t, expected, actual)
 }
+
+func TestRealGithub_Description_NoRemote(t *testing.T) {
+	gh := NewGithub("http://example.com", git.NewMock(), "", cache.NewMockAidyCache())
+	gh.ch.WithRemote("")
+
+	description, err := gh.Description("123")
+
+	require.Error(t, err, "Description should return an error when no remote is set")
+	assert.Equal(t, "cannot find a target repository to search for issue '123'", err.Error())
+	assert.Empty(t, description, "Description should be empty on error")
+}
+
+func TestRealGithub_Labels_NoRemote(t *testing.T) {
+	gh := NewGithub("http://example.com", git.NewMock(), "", cache.NewMockAidyCache())
+	gh.ch.WithRemote("")
+
+	labels, err := gh.Labels()
+
+	require.Error(t, err, "Labels should return an error when request creation fails")
+	assert.Contains(t, err.Error(), "cannot determine where to get labels, please set the target repository")
+	assert.Nil(t, labels, "Labels should be nil on error")
+}
+
+func TestRealGithub_Labels_UrlParsingError(t *testing.T) {
+	gh := NewGithub("\\invalid://url", git.NewMock(), "", cache.NewMockAidyCache())
+	gh.ch.WithRemote("invalid-url")
+
+	labels, err := gh.Labels()
+
+	require.Error(t, err, "Labels should return an error when request creation fails")
+	assert.Contains(t, err.Error(), "cannot create a new GET request to retrieve labels")
+	assert.Nil(t, labels, "Labels should be nil on error")
+}
+
+func TestRealGithub_Labels_InvalidProtocol(t *testing.T) {
+	gh := NewGithub("invalid://protocol", git.NewMock(), "", cache.NewMockAidyCache())
+	gh.ch.WithRemote("invalid-protocol")
+
+	labels, err := gh.Labels()
+
+	require.Error(t, err, "Labels should return an error when request creation fails")
+	assert.Contains(t, err.Error(), "error fetching issue labels")
+	assert.Contains(t, err.Error(), "unsupported protocol scheme \"invalid\"")
+	assert.Nil(t, labels, "Labels should be nil on error")
+}
+
+func TestRealGithub_Labels_DoRequestError(t *testing.T) {
+	gh := NewGithub("http://example.com", git.NewMock(), "", cache.NewMockAidyCache())
+	gh.ch.WithRemote("valid-repo")
+	gh.client = &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			return nil, fmt.Errorf("simulated request error")
+		}),
+	}
+
+	labels, err := gh.Labels()
+
+	require.Error(t, err, "Labels should return an error when HTTP request fails")
+	assert.Contains(t, err.Error(), "error fetching issue labels")
+	assert.Contains(t, err.Error(), "simulated request error")
+	assert.Nil(t, labels, "Labels should be nil on error")
+}
+
+type roundTripperFunc func(req *http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestRealGithub_Labels_Non200Response(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+	gh := NewGithub(ts.URL, git.NewMock(), "", cache.NewMockAidyCache())
+	gh.ch.WithRemote("valid-repo")
+
+	labels, err := gh.Labels()
+
+	require.Error(t, err, "Labels should return an error for non-200 response")
+	assert.Contains(t, err.Error(), "cannot retrieve labels using the following url")
+	assert.Contains(t, err.Error(), "response: '500 Internal Server Error'")
+	assert.Nil(t, labels, "Labels should be nil on error")
+}
+
+func TestRealGithub_Labels_UnmarshalError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte("invalid json")); err != nil {
+			t.Errorf("Error writing response: %v", err)
+		}
+	}))
+	defer ts.Close()
+	gh := NewGithub(ts.URL, git.NewMock(), "", cache.NewMockAidyCache())
+	gh.ch.WithRemote("valid-repo")
+
+	labels, err := gh.Labels()
+
+	require.Error(t, err, "Labels should return an error for JSON unmarshal failure")
+	assert.Contains(t, err.Error(), "error unmarshaling issue json")
+	assert.Nil(t, labels, "Labels should be nil on error")
+}
+
+func TestRealGithub_Remotes_Error(t *testing.T) {
+	git := git.NewMockWithError(fmt.Errorf("simulated git error"))
+	gh := NewGithub("", git, "", cache.NewMockAidyCache())
+
+	remotes, err := gh.Remotes()
+
+	require.Error(t, err, "Remotes should return an error when git remotes retrieval fails")
+	assert.Contains(t, err.Error(), "cannot retrieve git remotes")
+	assert.Contains(t, err.Error(), "simulated git error")
+	assert.Nil(t, remotes, "Remotes should be nil on error")
+}


### PR DESCRIPTION
This PR significantly improves test coverage by adding comprehensive unit tests for `github`, `git`, and `cache` packages, focusing on error cases and edge conditions.

Related to #106