### PR TITLE
fix(#179): Store config reference in Aidy struct to prevent nil pointer dereference

### DIFF
--- a/internal/aidy/real.go
+++ b/internal/aidy/real.go
@@ -52,6 +52,7 @@ func NewAidy(summary bool, aider bool, ailess bool) Aidy {
 	conf := newconf(aider, aidy.git)
 	aidy.ai = brain(ailess, summary, conf)
 	aidy.github = newgithub(aidy.git, conf, aidy.cache)
+	aidy.config = conf
 	aidy.initSummary(summary)
 	return &aidy
 }


### PR DESCRIPTION
Fixes a nil pointer dereference in `PrintConfig()` by properly initializing the `config` field in the `Aidy` struct.

Closes #179