### PR TITLE
feat(#178): add target repository selection when creating PRs

### DIFF
--- a/internal/github/real.go
+++ b/internal/github/real.go
@@ -48,7 +48,7 @@ func NewGithub(url string, gs git.Git, token string, ch cache.AidyCache) *github
 
 func (r *github) Description(number string) (string, error) {
 	if _, err := strconv.Atoi(number); err != nil {
-		return fmt.Sprintf("Invalid issue number: '%s'", number), nil
+		return fmt.Sprintf("invalid issue number: '%s'", number), nil
 	}
 	var task issue
 	target := r.ch.Remote()

--- a/internal/github/real_test.go
+++ b/internal/github/real_test.go
@@ -40,7 +40,7 @@ func TestRealGithub_Description_NotNumber(t *testing.T) {
 	description, err := gh.Description(issueNumber)
 
 	require.NoError(t, err, "Description should not return an error for non-numeric issue number")
-	assert.Equal(t, "Invalid issue number: 'not-a-number'", description)
+	assert.Equal(t, "invalid issue number: 'not-a-number'", description)
 }
 
 func TestRealGithub_Labels(t *testing.T) {


### PR DESCRIPTION
This PR adds repository target detection and selection when creating PRs, guiding users when no target is set.

Closes #178