### PR TITLE
fix(#184): handle 404 response for missing GitHub labels gracefully

### DIFF
--- a/internal/github/real.go
+++ b/internal/github/real.go
@@ -87,6 +87,9 @@ func (r *github) Labels() ([]string, error) {
 			}
 		}()
 		if resp.StatusCode != http.StatusOK {
+			if resp.StatusCode == http.StatusNotFound {
+				return []string{}, nil
+			}
 			return nil, fmt.Errorf("cannot retrieve labels using the following url: '%s'. response: '%s'", url, resp.Status)
 		}
 		body, err := io.ReadAll(resp.Body)


### PR DESCRIPTION
This PR modifies the `Labels()` method to return an empty slice instead of an error when GitHub returns a 404 response, handling repositories without labels gracefully.

Closes #184