### PR TITLE
fix(#183): handle branch names with numbers when creating PRs

### DIFF
--- a/internal/ai/mock.go
+++ b/internal/ai/mock.go
@@ -25,19 +25,19 @@ func (m *MockAI) ReleaseNotes(changes string) (string, error) {
 }
 
 func (m *MockAI) PrTitle(branchName string, diff string, issue string, summary string) (string, error) {
-	return "'Mock Title for " + branchName + "'", nil
+	return fmt.Sprintf("mock title for '%s' with issue #%s and summary: %s", branchName, issue, summary), nil
 }
 
-func (m *MockAI) PrBody(branchName string, diff string, issue string, summary string) (string, error) {
-	return "Mock Body for " + branchName, nil
+func (m *MockAI) PrBody(branch string, diff string, issue string, summary string) (string, error) {
+	return fmt.Sprintf("mock body for %s with issue #%s and summary: %s\n\ndiff:\n%s", branch, issue, summary, diff), nil
 }
 
-func (m *MockAI) IssueTitle(userInput string, summary string) (string, error) {
-	return "'Mock Issue Title for " + userInput + "'", nil
+func (m *MockAI) IssueTitle(input string, summary string) (string, error) {
+	return fmt.Sprintf("mock issue title for '%s' with summary: %s", input, summary), nil
 }
 
-func (m *MockAI) IssueBody(userInput string, summary string) (string, error) {
-	return "Mock Issue Body for " + userInput, nil
+func (m *MockAI) IssueBody(input string, summary string) (string, error) {
+	return fmt.Sprintf("mock issue body for '%s' with summary: %s", input, summary), nil
 }
 
 func (m *MockAI) CommitMessage(issue string, diff string) (string, error) {

--- a/internal/ai/mock_test.go
+++ b/internal/ai/mock_test.go
@@ -42,10 +42,10 @@ func TestMockGenerateLabels(t *testing.T) {
 	assert.Equal(t, labels, actual)
 }
 
-func TestMockGenerateTitle(t *testing.T) {
+func TestMock_GeneratePrTitle(t *testing.T) {
 	mockAI := NewMockAI()
 	branchName := "feature-branch"
-	expected := "'Mock Title for " + branchName + "'"
+	expected := fmt.Sprintf("mock title for '%s' with issue #issue and summary: summary", branchName)
 
 	title, err := mockAI.PrTitle(branchName, "diff", "issue", "summary")
 
@@ -53,37 +53,37 @@ func TestMockGenerateTitle(t *testing.T) {
 	assert.Equal(t, expected, title, "Expected title to match")
 }
 
-func TestMockGenerateIssueTitle(t *testing.T) {
+func TestMock_GenerateIssueTitle(t *testing.T) {
 	mockAI := NewMockAI()
-	userInput := "issue input"
-	expected := "'Mock Issue Title for " + userInput + "'"
+	input := "issue input"
+	expected := fmt.Sprintf("mock issue title for '%s' with summary: summary", input)
 
-	title, err := mockAI.IssueTitle(userInput, "summary")
+	title, err := mockAI.IssueTitle(input, "summary")
 
 	require.NoError(t, err, "Expected no error")
 	assert.Equal(t, expected, title, "Expected issue title to match")
 }
 
-func TestMockGenerateIssueBody(t *testing.T) {
+func TestMock_GenerateIssueBody(t *testing.T) {
 	mockAI := NewMockAI()
-	userInput := "issue input"
-	expected := "Mock Issue Body for " + userInput
+	input := "issue input"
+	expected := fmt.Sprintf("mock issue body for '%s' with summary: summary", input)
 
-	body, err := mockAI.IssueBody(userInput, "summary")
+	body, err := mockAI.IssueBody(input, "summary")
 
 	require.NoError(t, err, "Expected no error")
 	assert.Equal(t, expected, body, "Expected issue body to match")
 }
 
-func TestMockGenerateBody(t *testing.T) {
-	mockAI := NewMockAI()
-	branchName := "feature-branch"
-	expected := "Mock Body for " + branchName
+func TestMock_GenerateBody(t *testing.T) {
+	ai := NewMockAI()
+	branch := "feature-branch"
+	expected := fmt.Sprintf("mock body for %s with issue #issue and summary: summary\n\ndiff:\ndiff", branch)
 
-	body, err := mockAI.PrBody(branchName, "diff", "issue", "summary")
+	body, err := ai.PrBody(branch, "diff", "issue", "summary")
 
 	require.NoError(t, err, "Expected no error")
-	assert.Equal(t, expected, body, "Expected body to match")
+	assert.Contains(t, body, expected, "Expected body to match")
 }
 
 func TestMockAI_IssueLabels(t *testing.T) {

--- a/internal/aidy/real.go
+++ b/internal/aidy/real.go
@@ -284,7 +284,8 @@ func (r *real) PullRequest() error {
 	nissue := inumber(branch)
 	issue, err := r.github.Description(nissue)
 	if err != nil {
-		return fmt.Errorf("error retrieving pull request description: %v", err)
+		issue = "not-found"
+		log.Printf("warning: issue description not found for issue #%s, using default value", nissue)
 	}
 	title, err := r.ai.PrTitle(nissue, diff, issue, summary)
 	if err != nil {

--- a/internal/github/mock.go
+++ b/internal/github/mock.go
@@ -1,19 +1,23 @@
 package github
 
-type MockGithub struct{}
+import "fmt"
+
+type MockGithub struct {
+	Error error
+}
 
 func NewMock() *MockGithub {
-	return &MockGithub{}
+	return &MockGithub{Error: nil}
 }
 
 func (m *MockGithub) Description(number string) (string, error) {
-	return "Mock description for issue #" + number, nil
+	return fmt.Sprintf("mock description for issue '#%s'", number), m.Error
 }
 
 func (m *MockGithub) Labels() ([]string, error) {
-	return []string{"bug", "documentation", "question"}, nil
+	return []string{"bug", "documentation", "question"}, m.Error
 }
 
 func (m *MockGithub) Remotes() ([]string, error) {
-	return []string{"volodya-lombrozo/aidy", "volodya-lombrozo/jtcop"}, nil
+	return []string{"volodya-lombrozo/aidy", "volodya-lombrozo/jtcop"}, m.Error
 }

--- a/internal/github/mock_test.go
+++ b/internal/github/mock_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,7 +11,8 @@ import (
 func TestMockGithub_IssueDescription(t *testing.T) {
 	mock := NewMock()
 	number := "123"
-	expected := "Mock description for issue #" + number
+	expected := fmt.Sprintf("mock description for issue '#%s'", number)
+
 
 	description, err := mock.Description(number)
 

--- a/internal/github/real_test.go
+++ b/internal/github/real_test.go
@@ -176,6 +176,7 @@ func TestRealGithub_Labels_500Response(t *testing.T) {
 	assert.Contains(t, err.Error(), "response: '500 Internal Server Error'")
 	assert.Nil(t, labels, "Labels should be nil on error")
 }
+
 func TestRealGithub_Labels_Non404Response(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)


### PR DESCRIPTION
This PR improves error handling when creating pull requests from branches containing numbers, falling back to a default value when the GitHub issue is not found.

Closes #183