### PR TITLE
fix(#180): Mask sensitive tokens in configuration output

### DIFF
--- a/internal/aidy/real.go
+++ b/internal/aidy/real.go
@@ -236,32 +236,39 @@ func healPRTitle(text string, issue string) string {
 }
 
 func (r *real) PrintConfig() error {
-	r.print("Aidy Configuration:\n")
+	r.print("aidy configuration:")
 	openai, err := r.config.OpenAiKey()
 	if err != nil {
-		r.print(fmt.Sprintf("Error retrieving OpenAI API key: %v\n", err))
+		r.print(fmt.Sprintf("error retrieving openai api key: %v", err))
 	} else {
-		r.print(fmt.Sprintf("OpenAI API Key: %s\n", openai))
+		r.print(fmt.Sprintf("openai api key: %s", mask(openai)))
 	}
 	deepseek, err := r.config.DeepseekKey()
 	if err != nil {
-		r.print(fmt.Sprintf("Error retrieving Deepseek API key: %v\n", err))
+		r.print(fmt.Sprintf("error retrieving deepseek api key: %v", err))
 	} else {
-		r.print(fmt.Sprintf("Deepseek API Key: %s\n", deepseek))
+		r.print(fmt.Sprintf("deepseek api key: %s", mask(deepseek)))
 	}
 	gh, err := r.config.GithubKey()
 	if err != nil {
-		r.print(fmt.Sprintf("Error retrieving GitHub API key: %v\n", err))
+		r.print(fmt.Sprintf("error retrieving github api key: %v", err))
 	} else {
-		r.print(fmt.Sprintf("GitHub API Key: %s\n", gh))
+		r.print(fmt.Sprintf("github api key: %s", mask(gh)))
 	}
 	model, err := r.config.Model()
 	if err != nil {
-		r.print(fmt.Sprintf("Error retrieving model: %v\n", err))
+		r.print(fmt.Sprintf("error retrieving model: %v\n", err))
 	} else {
-		r.print(fmt.Sprintf("Model: %s\n", model))
+		r.print(fmt.Sprintf("model: %s\n", model))
 	}
 	return err
+}
+
+func mask(key string) string {
+	if len(key) <= 4 {
+		return strings.Repeat("*", len(key))
+	}
+	return strings.Repeat("*", len(key)-4) + key[len(key)-4:]
 }
 
 func (r *real) print(msg string) {

--- a/internal/aidy/real_test.go
+++ b/internal/aidy/real_test.go
@@ -96,18 +96,42 @@ func TestReal_PrintConfig_Successful(t *testing.T) {
 	require.NoError(t, err, "Expected no error when printing configuration")
 	res := printer.Captured()
 	expected := strings.Join([]string{
-		"Aidy Configuration:",
-		"",
-		"OpenAI API Key: mock-openai-key",
-		"",
-		"Deepseek API Key: mock-deepseek-key",
-		"",
-		"GitHub API Key: mock-github-key",
-		"",
-		"Model: gpt-4o",
+		"aidy configuration:",
+		"openai api key: ***********-key",
+		"deepseek api key: *************-key",
+		"github api key: ***********-key",
+		"model: gpt-4o",
 		"",
 	}, "\n")
 	assert.Equal(t, expected, res, "Expected configuration to match")
+}
+
+func TestReal_PrintConfig_ShortKeys(t *testing.T) {
+	printer := output.NewMock()
+	conf := config.NewMock()
+	conf.MockDeepseek = "short"
+	raidy := &real{config: conf, printer: printer}
+
+	err := raidy.PrintConfig()
+
+	require.NoError(t, err, "Expected no error when printing configuration")
+	res := printer.Captured()
+	assert.Contains(t, res, "aidy configuration:")
+	assert.Contains(t, res, "deepseek api key: *hort")
+}
+
+func TestReal_PrintConfig_TooShort(t *testing.T) {
+	printer := output.NewMock()
+	conf := config.NewMock()
+	conf.MockOpenai = "123"
+	raidy := &real{config: conf, printer: printer}
+
+	err := raidy.PrintConfig()
+
+	require.NoError(t, err, "Expected no error when printing configuration with short key")
+	res := printer.Captured()
+	assert.Contains(t, res, "aidy configuration:")
+	assert.Contains(t, res, "openai api key: ***")
 }
 
 func TestReal_PrintConfig_NoConfig(t *testing.T) {
@@ -121,15 +145,11 @@ func TestReal_PrintConfig_NoConfig(t *testing.T) {
 	require.Error(t, err, "Expected no error when printing configuration with no config")
 	res := printer.Captured()
 	expected := strings.Join([]string{
-		"Aidy Configuration:",
-		"",
-		"Error retrieving OpenAI API key: no configuration found",
-		"",
-		"Error retrieving Deepseek API key: no configuration found",
-		"",
-		"Error retrieving GitHub API key: no configuration found",
-		"",
-		"Error retrieving model: no configuration found",
+		"aidy configuration:",
+		"error retrieving openai api key: no configuration found",
+		"error retrieving deepseek api key: no configuration found",
+		"error retrieving github api key: no configuration found",
+		"error retrieving model: no configuration found",
 		"",
 	}, "\n")
 	assert.Equal(t, expected, res, "Expected error message when no config is found")

--- a/internal/github/mock_test.go
+++ b/internal/github/mock_test.go
@@ -13,7 +13,6 @@ func TestMockGithub_IssueDescription(t *testing.T) {
 	number := "123"
 	expected := fmt.Sprintf("mock description for issue '#%s'", number)
 
-
 	description, err := mock.Description(number)
 
 	require.NoError(t, err, "mock object should not return errors")


### PR DESCRIPTION
This PR masks sensitive API keys when printing configuration by replacing all but the last 4 characters with `*` symbols.

Closes #180