### PR TITLE
test(#106): Add coverage workflow and improve test coverage

### DIFF
--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -1,0 +1,30 @@
+name: Test with Coverage
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+      - name: Run tests with coverage
+        run: |
+          go test ./... -coverprofile=coverage.out
+      - name: Check code coverage
+        run: |
+          coverage=$(go tool cover -func=coverage.out | grep total: | awk '{print $3}' | sed 's/%//')
+          echo "Coverage is $coverage%"
+          threshold=85.0
+          result=$(echo "$coverage < $threshold" | bc -l)
+          if [ "$result" -eq 1 ]; then
+            echo "Code coverage is below $threshold%"
+            exit 1
+          fi
+

--- a/internal/config/cascade_test.go
+++ b/internal/config/cascade_test.go
@@ -18,7 +18,7 @@ api-keys:
   deepseek: test-deepseek-key
 models:
   test-model:
-    provider: mock
+    provider: deepseek
     model-id: test-model-1
 `
 
@@ -58,6 +58,14 @@ func TestCascade_AidyFirst(t *testing.T) {
 	model, err := conf.Model()
 	assert.NoError(t, err)
 	assert.Equal(t, "test-model-1", model)
+
+	token, err := conf.Token()
+	assert.NoError(t, err)
+	assert.Equal(t, "test-deepseek-key", token, "Token should match")
+
+	provider, err := conf.Provider()
+	assert.NoError(t, err)
+	assert.Equal(t, "deepseek", provider, "Provider should match")
 }
 
 func TestCascade_AiderFirst(t *testing.T) {
@@ -92,6 +100,14 @@ func TestCascade_AiderFirst(t *testing.T) {
 	model, err := conf.Model()
 	assert.NoError(t, err)
 	assert.Equal(t, "gpt-4o-test", model)
+
+	token, err := conf.Token()
+	assert.NoError(t, err)
+	assert.Equal(t, "test-openai-key", token, "Token should match")
+
+	token, err = conf.Provider()
+	assert.NoError(t, err)
+	assert.Equal(t, "openai", token, "Provider should match")
 }
 
 func tmpConfFile(t *testing.T, dir, filename, content string) string {

--- a/internal/git/mock.go
+++ b/internal/git/mock.go
@@ -62,7 +62,6 @@ func (m *mock) Tags(repo string) ([]string, error) {
 		log.Printf("No tags found in repository %s", repo)
 		return []string{}, nil
 	}
-
 	log.Printf("Fetched tags from repository %s: %s", repo, res)
 	return []string{"v1.0", "v2.0"}, nil
 }

--- a/internal/git/mock_test.go
+++ b/internal/git/mock_test.go
@@ -9,6 +9,26 @@ import (
 	"github.com/volodya-lombrozo/aidy/internal/executor"
 )
 
+func TestMock_Tags_Absent(t *testing.T) {
+	shell := executor.NewMock()
+	shell.Output = "absent"
+	git := NewMockWithShell(shell)
+
+	res, err := git.Tags("does-not-matter")
+
+	require.NoError(t, err)
+	assert.Empty(t, res, "Expected no tags when output is 'absent'")
+}
+
+func TestMock_Tags_Error(t *testing.T) {
+	git := NewMockWithError(fmt.Errorf("mock error"))
+
+	_, err := git.Tags("does-not-matter")
+
+	assert.Error(t, err)
+	assert.Equal(t, "mock error", err.Error())
+}
+
 func TestMock_Log_Success(t *testing.T) {
 	git := NewMock()
 


### PR DESCRIPTION
This PR adds a GitHub Actions workflow for test coverage enforcement and expands test coverage for `internal/config` and `internal/git` packages to meet our `85%` threshold.

Related to #106