### PR TITLE
refactor(#199): Remove deprecated config methods and clean up interface

### DIFF
--- a/internal/aidy/real.go
+++ b/internal/aidy/real.go
@@ -257,29 +257,29 @@ func healPRTitle(text string, issue string) string {
 
 func (r *real) PrintConfig() error {
 	r.print("aidy configuration:")
-	openai, err := r.config.OpenAiKey()
+	provider, err := r.config.Provider()
 	if err != nil {
-		r.print(fmt.Sprintf("error retrieving openai api key: %v", err))
+		r.print(fmt.Sprintf("error retrieving AI provider: %v", err))
 	} else {
-		r.print(fmt.Sprintf("openai api key: %s", mask(openai)))
-	}
-	deepseek, err := r.config.DeepseekKey()
-	if err != nil {
-		r.print(fmt.Sprintf("error retrieving deepseek api key: %v", err))
-	} else {
-		r.print(fmt.Sprintf("deepseek api key: %s", mask(deepseek)))
-	}
-	gh, err := r.config.GithubKey()
-	if err != nil {
-		r.print(fmt.Sprintf("error retrieving github api key: %v", err))
-	} else {
-		r.print(fmt.Sprintf("github api key: %s", mask(gh)))
+		r.print(fmt.Sprintf("AI provider: %s", provider))
 	}
 	model, err := r.config.Model()
 	if err != nil {
-		r.print(fmt.Sprintf("error retrieving model: %v\n", err))
+		r.print(fmt.Sprintf("error retrieving model: %v", err))
 	} else {
-		r.print(fmt.Sprintf("model: %s\n", model))
+		r.print(fmt.Sprintf("model: %s", model))
+	}
+	token, err := r.config.Token()
+	if err != nil {
+		r.print(fmt.Sprintf("error retrieving AI token: %v", err))
+	} else {
+		r.print(fmt.Sprintf("AI API token: %s", mask(token)))
+	}
+	gh, err := r.config.GithubKey()
+	if err != nil {
+		r.print(fmt.Sprintf("error retrieving GitHub API key: %v", err))
+	} else {
+		r.print(fmt.Sprintf("GitHub API key: %s", mask(gh)))
 	}
 	return err
 }

--- a/internal/aidy/real_test.go
+++ b/internal/aidy/real_test.go
@@ -345,11 +345,10 @@ func TestReal_PrintConfig_Successful(t *testing.T) {
 	res := printer.Captured()
 	expected := strings.Join([]string{
 		"aidy configuration:",
-		"openai api key: ***********-key",
-		"deepseek api key: *************-key",
-		"github api key: ***********-key",
+		"AI provider: openai",
 		"model: gpt-4o",
-		"",
+		"AI API token: ******oken",
+		"GitHub API key: ***********-key",
 	}, "\n")
 	assert.Equal(t, expected, res, "Expected configuration to match")
 }
@@ -357,7 +356,7 @@ func TestReal_PrintConfig_Successful(t *testing.T) {
 func TestReal_PrintConfig_ShortKeys(t *testing.T) {
 	printer := output.NewMock()
 	conf := config.NewMock()
-	conf.MockDeepseek = "short"
+	conf.MockToken = "short"
 	raidy := &real{config: conf, printer: printer}
 
 	err := raidy.PrintConfig()
@@ -365,13 +364,13 @@ func TestReal_PrintConfig_ShortKeys(t *testing.T) {
 	require.NoError(t, err, "Expected no error when printing configuration")
 	res := printer.Captured()
 	assert.Contains(t, res, "aidy configuration:")
-	assert.Contains(t, res, "deepseek api key: *hort")
+	assert.Contains(t, res, "AI API token: *hort")
 }
 
 func TestReal_PrintConfig_TooShort(t *testing.T) {
 	printer := output.NewMock()
 	conf := config.NewMock()
-	conf.MockOpenai = "123"
+	conf.MockToken = "123"
 	raidy := &real{config: conf, printer: printer}
 
 	err := raidy.PrintConfig()
@@ -379,7 +378,7 @@ func TestReal_PrintConfig_TooShort(t *testing.T) {
 	require.NoError(t, err, "Expected no error when printing configuration with short key")
 	res := printer.Captured()
 	assert.Contains(t, res, "aidy configuration:")
-	assert.Contains(t, res, "openai api key: ***")
+	assert.Contains(t, res, "API token: ***")
 }
 
 func TestReal_PrintConfig_NoConfig(t *testing.T) {
@@ -394,11 +393,10 @@ func TestReal_PrintConfig_NoConfig(t *testing.T) {
 	res := printer.Captured()
 	expected := strings.Join([]string{
 		"aidy configuration:",
-		"error retrieving openai api key: no configuration found",
-		"error retrieving deepseek api key: no configuration found",
-		"error retrieving github api key: no configuration found",
+		"error retrieving AI provider: no configuration found",
 		"error retrieving model: no configuration found",
-		"",
+		"error retrieving AI token: no configuration found",
+		"error retrieving GitHub API key: no configuration found",
 	}, "\n")
 	assert.Equal(t, expected, res, "Expected error message when no config is found")
 }

--- a/internal/config/aider.go
+++ b/internal/config/aider.go
@@ -23,10 +23,6 @@ func NewAider(filepath string) (*AiderConfig, error) {
 	return &config, nil
 }
 
-func (c *AiderConfig) OpenAiKey() (string, error) {
-	return c.OpenaiApiKeyYaml, nil
-}
-
 func (c *AiderConfig) GithubKey() (string, error) {
 	return "", nil
 }
@@ -35,14 +31,10 @@ func (c *AiderConfig) Model() (string, error) {
 	return c.ModelYaml, nil
 }
 
-func (c *AiderConfig) DeepseekKey() (string, error) {
-	return "unknown", nil
-}
-
 func (c *AiderConfig) Provider() (string, error) {
 	return "openai", nil
 }
 
 func (c *AiderConfig) Token() (string, error) {
-	return c.OpenAiKey()
+	return c.OpenaiApiKeyYaml, nil
 }

--- a/internal/config/aider_test.go
+++ b/internal/config/aider_test.go
@@ -13,21 +13,6 @@ model: 4o
 openai-api-key: secret-key
 `
 
-func TestAider_OpenAiKey(t *testing.T) {
-	tmp := t.TempDir()
-	path := tmp + "/config.yml"
-	content := []byte(example)
-	err := os.WriteFile(path, content, 0644)
-	require.NoError(t, err, "Failed to write config file")
-	config, err := NewAider(path)
-	require.NoError(t, err, "Failed to load config")
-
-	apiKey, err := config.OpenAiKey()
-
-	require.NoError(t, err, "Error should be nil")
-	assert.Equal(t, "secret-key", apiKey, "API key should match")
-}
-
 func TestAider_Model(t *testing.T) {
 	tmp := t.TempDir()
 	path := tmp + "/config.yml"
@@ -40,20 +25,6 @@ func TestAider_Model(t *testing.T) {
 
 	assert.NoError(t, err, "Error should be nil")
 	assert.Equal(t, "4o", apiKey, "Model should match")
-}
-
-func TestAider_DeepseekKey(t *testing.T) {
-	tmp := t.TempDir()
-	path := tmp + "/config.yml"
-	err := os.WriteFile(path, []byte(example), 0644)
-	require.NoError(t, err, "Failed to write config file")
-	config, err := NewAider(path)
-	require.NoError(t, err, "Failed to load config")
-
-	apiKey, err := config.DeepseekKey()
-
-	assert.NoError(t, err, "Error should be nil")
-	assert.Equal(t, "unknown", apiKey, "Deepseek key should match")
 }
 
 func TestAider_GithubKey(t *testing.T) {

--- a/internal/config/cascade.go
+++ b/internal/config/cascade.go
@@ -27,16 +27,8 @@ func NewCascadeInDirs(folders ...func() (string, error)) (Config, error) {
 	return &CascadeConfig{original: original}, nil
 }
 
-func (c *CascadeConfig) OpenAiKey() (string, error) {
-	return c.original.OpenAiKey()
-}
-
 func (c *CascadeConfig) GithubKey() (string, error) {
 	return c.original.GithubKey()
-}
-
-func (c *CascadeConfig) DeepseekKey() (string, error) {
-	return c.original.DeepseekKey()
 }
 
 func (c *CascadeConfig) Model() (string, error) {

--- a/internal/config/cascade_test.go
+++ b/internal/config/cascade_test.go
@@ -41,19 +41,11 @@ func TestCascade_AidyFirst(t *testing.T) {
 	err = os.Chdir(tmp)
 	require.NoError(t, err, "Failed to change directory to temp dir")
 	conf, err := NewCascade(git.NewMock())
-
 	require.NoError(t, err, "Failed to create cascade config")
-	openAIKey, err := conf.OpenAiKey()
-	assert.NoError(t, err)
-	assert.Equal(t, "test-openai-key", openAIKey)
 
 	githubKey, err := conf.GithubKey()
 	assert.NoError(t, err)
 	assert.Equal(t, "test-github-key", githubKey)
-
-	deepseekKey, err := conf.DeepseekKey()
-	assert.NoError(t, err)
-	assert.Equal(t, "test-deepseek-key", deepseekKey)
 
 	model, err := conf.Model()
 	assert.NoError(t, err)
@@ -85,17 +77,9 @@ func TestCascade_AiderFirst(t *testing.T) {
 	conf, err := NewCascadeInDirs(folder)
 	require.NoError(t, err, "Failed to create cascade config")
 
-	openai, err := conf.OpenAiKey()
-	assert.NoError(t, err)
-	assert.Equal(t, "test-openai-key", openai)
-
 	github, err := conf.GithubKey()
 	assert.NoError(t, err)
 	assert.Equal(t, "", github)
-
-	deepseek, err := conf.DeepseekKey()
-	assert.NoError(t, err)
-	assert.Equal(t, "unknown", deepseek)
 
 	model, err := conf.Model()
 	assert.NoError(t, err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,10 +1,8 @@
 package config
 
 type Config interface {
-	OpenAiKey() (string, error)
-	GithubKey() (string, error)
-	DeepseekKey() (string, error)
-	Model() (string, error)
 	Provider() (string, error)
+	Model() (string, error)
 	Token() (string, error)
+	GithubKey() (string, error)
 }

--- a/internal/config/mock.go
+++ b/internal/config/mock.go
@@ -1,8 +1,6 @@
 package config
 
 type MockConfig struct {
-	MockDeepseek string
-	MockOpenai   string
 	MockGithub   string
 	MockModel    string
 	Error        error
@@ -12,17 +10,11 @@ type MockConfig struct {
 
 func NewMock() *MockConfig {
 	return &MockConfig{
-		MockOpenai:   "mock-openai-key",
 		MockGithub:   "mock-github-key",
-		MockDeepseek: "mock-deepseek-key",
 		MockModel:    "gpt-4o",
 		MockToken:    "mock-token",
 		MockProvider: "openai",
 	}
-}
-
-func (m *MockConfig) DeepseekKey() (string, error) {
-	return m.MockDeepseek, m.Error
 }
 
 func (m *MockConfig) GithubKey() (string, error) {
@@ -31,10 +23,6 @@ func (m *MockConfig) GithubKey() (string, error) {
 
 func (m *MockConfig) Model() (string, error) {
 	return m.MockModel, m.Error
-}
-
-func (m *MockConfig) OpenAiKey() (string, error) {
-	return m.MockOpenai, m.Error
 }
 
 func (m *MockConfig) Provider() (string, error) {

--- a/internal/config/mock_test.go
+++ b/internal/config/mock_test.go
@@ -7,17 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMock_OpenAiKey(t *testing.T) {
-	expected := "test-api-key"
-	conf := NewMock()
-	conf.MockOpenai = expected
-
-	key, err := conf.OpenAiKey()
-
-	require.NoError(t, err, "Expected no error when getting OpenAI API key")
-	assert.Equal(t, expected, key, "Expected OpenAI API key to match the mock value")
-}
-
 func TestMock_GithubKey(t *testing.T) {
 	expected := "github-api-key"
 	conf := NewMock()
@@ -27,17 +16,6 @@ func TestMock_GithubKey(t *testing.T) {
 
 	require.NoError(t, err, "Expected no error when getting GitHub API key")
 	assert.Equal(t, expected, key, "Expected GitHub API key to match the mock value")
-}
-
-func TestMock_DeepseekKey(t *testing.T) {
-	expected := "deepseek-api-key"
-	conf := NewMock()
-	conf.MockDeepseek = expected
-
-	key, err := conf.DeepseekKey()
-
-	require.NoError(t, err, "Expected no error when getting Deepseek API key")
-	assert.Equal(t, expected, key, "Expected Deepseek API key to match the mock value")
 }
 
 func TestMock_Model(t *testing.T) {

--- a/internal/config/yaml_test.go
+++ b/internal/config/yaml_test.go
@@ -126,22 +126,6 @@ func TestYamlConfModelOnly(t *testing.T) {
 	assert.Equal(t, "gpt-4o", model, "Model ID should match")
 }
 
-func TestGetOpenAIAPIKey(t *testing.T) {
-	tmp, err := os.MkdirTemp("", "configtest")
-	require.NoError(t, err, "Failed to create temp dir")
-	defer clean(t, tmp)
-	path := tmp + "/config.yml"
-	err = os.WriteFile(path, []byte(KEYS), 0644)
-	require.NoError(t, err, "Failed to write config file")
-	config, err := YamlConf(path)
-	require.NoError(t, err, "Failed to load config")
-
-	key, err := config.OpenAiKey()
-
-	assert.NoError(t, err, "Error should be nil")
-	assert.Equal(t, "sk-test", key, "API key should match")
-}
-
 func TestGetGithubAPIKey(t *testing.T) {
 	tmp, err := os.MkdirTemp("", "configtest")
 	require.NoError(t, err, "Failed to create temo dir")


### PR DESCRIPTION
This PR removes redundant and deprecated methods from the `Config` interface and related implementations to simplify the configuration system.

Closes #199