### PR TITLE
feat(#53): apply new logger in the real aidy implementation

### DIFF
--- a/internal/log/logger.go
+++ b/internal/log/logger.go
@@ -1,7 +1,7 @@
 package log
 
 type Logger interface {
-	Info(args ...any)
-	Debug(args ...any)
-	Warn(args ...any)
+	Info(string, ...any)
+	Debug(string, ...any)
+	Warn(string, ...any)
 }

--- a/internal/log/mock.go
+++ b/internal/log/mock.go
@@ -10,14 +10,14 @@ func NewMock() *Mock {
 	return &Mock{Messages: []string{}}
 }
 
-func (m *Mock) Info(args ...any) {
-	m.Messages = append(m.Messages, fmt.Sprintf("mock info: %v", args...))
+func (m *Mock) Info(msg string, args ...any) {
+	m.Messages = append(m.Messages, fmt.Sprintf("mock info: %v", fmt.Sprintf(msg, args...)))
 }
 
-func (m *Mock) Debug(args ...any) {
-	m.Messages = append(m.Messages, fmt.Sprintf("mock dubug: %v", args...))
+func (m *Mock) Debug(msg string, args ...any) {
+	m.Messages = append(m.Messages, fmt.Sprintf("mock dubug: %v", fmt.Sprintf(msg, args...)))
 }
 
-func (m *Mock) Warn(args ...any) {
-	m.Messages = append(m.Messages, fmt.Sprintf("mock warn: %v", args...))
+func (m *Mock) Warn(msg string, args ...any) {
+	m.Messages = append(m.Messages, fmt.Sprintf("mock warn: %v", fmt.Sprintf(msg, args...)))
 }

--- a/internal/log/short.go
+++ b/internal/log/short.go
@@ -17,16 +17,16 @@ func NewShort(original Logger) Logger {
 	}
 }
 
-func (s *Short) Debug(args ...any) {
-	s.Original.Debug(s.logShortf("%v", args...))
+func (s *Short) Debug(msg string, args ...any) {
+	s.Original.Debug(s.logShortf(msg, args...))
 }
 
-func (s *Short) Info(args ...any) {
-	s.Original.Info(s.logShortf("%v", args...))
+func (s *Short) Info(msg string, args ...any) {
+	s.Original.Info(s.logShortf(msg, args...))
 }
 
-func (s *Short) Warn(args ...any) {
-	s.Original.Warn(s.logShortf("%v", args...))
+func (s *Short) Warn(msg string, args ...any) {
+	s.Original.Warn(s.logShortf(msg, args...))
 }
 
 func (s *Short) logShortf(format string, args ...any) string {

--- a/internal/log/silent.go
+++ b/internal/log/silent.go
@@ -7,11 +7,11 @@ func NewSilent() Logger {
 	return &Silent{}
 }
 
-func (s *Silent) Info(args ...any) {
+func (s *Silent) Info(msg string, args ...any) {
 }
 
-func (s *Silent) Debug(args ...any) {
+func (s *Silent) Debug(msg string, args ...any) {
 }
 
-func (s *Silent) Warn(args ...any) {
+func (s *Silent) Warn(msg string, args ...any) {
 }

--- a/internal/log/zerolog.go
+++ b/internal/log/zerolog.go
@@ -16,14 +16,14 @@ func NewZerolog(writer io.Writer) Logger {
 	}
 }
 
-func (z *Zerolog) Info(args ...any) {
-	z.logger.Info().Msgf("%v", args...)
+func (z *Zerolog) Info(msg string, args ...any) {
+	z.logger.Info().Msgf(msg, args...)
 }
 
-func (z *Zerolog) Debug(args ...any) {
-	z.logger.Debug().Msgf("%v", args...)
+func (z *Zerolog) Debug(msg string, args ...any) {
+	z.logger.Debug().Msgf(msg, args...)
 }
 
-func (z *Zerolog) Warn(args ...any) {
-	z.logger.Warn().Msgf("%v", args...)
+func (z *Zerolog) Warn(msg string, args ...any) {
+	z.logger.Warn().Msgf(msg, args...)
 }

--- a/internal/log/zerolog_test.go
+++ b/internal/log/zerolog_test.go
@@ -33,3 +33,10 @@ func TestZerolog_Warn(t *testing.T) {
 
 	assert.Contains(t, buf.String(), "This is a warning message", "Expected warning message to be logged")
 }
+
+func TestZerolog_Info_Parametrised(t *testing.T) {
+	var buf bytes.Buffer
+	logger := NewZerolog(&buf)
+	logger.Info("This is an info message with param: %d", 42)
+	assert.Contains(t, buf.String(), "This is an info message with param: 42", "Expected info message with parameter to be logged")
+}


### PR DESCRIPTION
In this PR I just applied the new logger in `aidy/real.go` implementation. This move required some additional rafactoring changes.

Related to #53