### PR TITLE
feat(#53): add quiet and debug flags for log verbosity control

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,26 +13,30 @@ func Execute() error {
 	return newRootCmd(real).Execute()
 }
 
-func real(summary, aider, ailess bool) aidy.Aidy {
-	return aidy.NewAidy(summary, aider, ailess)
+func real(summary, aider, ailess, silent, debug bool) aidy.Aidy {
+	return aidy.NewAidy(summary, aider, ailess, silent, debug)
 }
 
-func newRootCmd(create func(bool, bool, bool) aidy.Aidy) *cobra.Command {
+func newRootCmd(create func(bool, bool, bool, bool, bool) aidy.Aidy) *cobra.Command {
 	var ctx Context
 	var ailess bool
 	var aider bool
 	var summary bool
+	var silent bool
+	var debug bool
 	root := &cobra.Command{
 		Use:   "aidy",
 		Short: "aidy - ai-powered github cli helper",
 		Long:  "Aidy assists you with generating commit messages, pull requests, issues, and releases",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			ctx.Assistant = create(summary, aider, ailess)
+			ctx.Assistant = create(summary, aider, ailess, silent, debug)
 		},
 	}
-	root.PersistentFlags().BoolVarP(&ailess, "no-ai", "n", false, "don't use ai")
-	root.PersistentFlags().BoolVarP(&summary, "summary", "s", false, "use a project summary in ai requests")
+	root.PersistentFlags().BoolVarP(&ailess, "no-ai", "n", false, "don't use AI")
+	root.PersistentFlags().BoolVarP(&summary, "summary", "s", false, "use a project summary in AI requests")
 	root.PersistentFlags().BoolVar(&aider, "aider", false, "use aider configuration")
+	root.PersistentFlags().BoolVarP(&silent, "quiet", "q", false, "be silent, don't print logs")
+	root.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "print debug logs")
 	root.AddCommand(
 		newCommitCmd(&ctx),
 		newIssueCmd(&ctx),

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -28,6 +28,6 @@ func TestRootCmd_Executes_WithoutError(t *testing.T) {
 	assert.NoError(t, err, "no error expected")
 }
 
-func mock(summary, aider, ailess bool) aidy.Aidy {
+func mock(summary, aider, ailess, silent, debug bool) aidy.Aidy {
 	return aidy.NewMock()
 }

--- a/internal/aidy/real_test.go
+++ b/internal/aidy/real_test.go
@@ -857,3 +857,30 @@ func TestUpver(t *testing.T) {
 	}
 
 }
+
+func TestInitLogger_DebugMode(t *testing.T) {
+	InitLogger(false, true)
+
+	logger := log.Get()
+
+	assert.NotNil(t, logger, "Expected logger to be initialized")
+	assert.IsType(t, &log.Short{}, logger, "Expected logger to be of type Short")
+}
+
+func TestInitLogger_SilentMode(t *testing.T) {
+	InitLogger(true, false)
+
+	logger := log.Get()
+
+	assert.NotNil(t, logger, "Expected logger to be initialized")
+	assert.IsType(t, &log.Silent{}, logger, "Expected logger to be of type Silent")
+}
+
+func TestInitLogger_DefaultMode(t *testing.T) {
+	InitLogger(false, false)
+
+	logger := log.Get()
+
+	assert.NotNil(t, logger, "Expected logger to be initialized")
+	assert.IsType(t, &log.Short{}, logger, "Expected logger to be of type Short")
+}

--- a/internal/executor/real.go
+++ b/internal/executor/real.go
@@ -21,7 +21,7 @@ func NewReal() Executor {
 		out: os.Stdout,
 		in:  os.Stdin,
 		err: os.Stderr,
-		log: log.NewShort(log.NewZerolog(os.Stdout)),
+		log: log.Get(),
 	}
 }
 

--- a/internal/executor/real_test.go
+++ b/internal/executor/real_test.go
@@ -34,7 +34,7 @@ func TestRealExecutor_RunCommandInDir(t *testing.T) {
 }
 
 func TestRealExecutor_RunInteractively(t *testing.T) {
-	executor := &RealExecutor{log: log.NewShort(log.NewZerolog(os.Stdout))}
+	executor := &RealExecutor{log: log.Get()}
 	r, w, err := os.Pipe()
 	require.NoError(t, err, "Failed to create pipe for stdout")
 	executor.out = w

--- a/internal/git/real.go
+++ b/internal/git/real.go
@@ -30,7 +30,7 @@ func NewGitFallback(shell executor.Executor, fallback func() (string, error), di
 			return nil, fmt.Errorf("failed to get current working directory: %w", err)
 		}
 	}
-	return &real{dir: directory, shell: shell, log: log.NewShort(log.NewZerolog(os.Stdout))}, nil
+	return &real{dir: directory, shell: shell, log: log.Get()}, nil
 }
 
 func (r *real) Run(arg ...string) (string, error) {

--- a/internal/github/real.go
+++ b/internal/github/real.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"regexp"
 	"sort"
 	"strconv"
@@ -45,7 +44,7 @@ func NewGithub(url string, gs git.Git, token string, ch cache.AidyCache) *github
 		git:    gs,
 		token:  token,
 		ch:     ch,
-		log:    log.NewShort(log.NewZerolog(os.Stdout)),
+		log:    log.Get(),
 	}
 }
 

--- a/internal/log/logger.go
+++ b/internal/log/logger.go
@@ -1,8 +1,26 @@
 package log
 
+import "os"
+
 type Logger interface {
 	Info(string, ...any)
 	Debug(string, ...any)
 	Warn(string, ...any)
 	Error(string, ...any)
+}
+
+var main Logger = NewShort(NewZerolog(os.Stdout, "debug"))
+
+func Set(logger Logger) {
+	if logger == nil {
+		panic("logger cannot be nil")
+	}
+	main = logger
+}
+
+func Get() Logger {
+	if main == nil {
+		panic("logger is not set")
+	}
+	return main
 }

--- a/internal/log/logger_test.go
+++ b/internal/log/logger_test.go
@@ -1,0 +1,34 @@
+package log
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetAndGetLogger(t *testing.T) {
+	mock := NewMock()
+	Set(mock)
+
+	initialised := Get()
+
+	assert.Equal(t, mock, initialised, "Expected retrieved logger to be the mock logger")
+}
+
+func TestSetLoggerNilPanics(t *testing.T) {
+	assert.Panics(t, func() {
+		Set(nil)
+	}, "Expected panic when setting logger to nil")
+}
+
+func TestGetLoggerNotSetPanics(t *testing.T) {
+	original := main
+	defer func() {
+		main = original
+	}()
+	main = nil
+	require.Panics(t, func() {
+		Get()
+	}, "Expected panic when getting logger that is not set")
+}

--- a/internal/log/zerolog.go
+++ b/internal/log/zerolog.go
@@ -10,9 +10,13 @@ type Zerolog struct {
 	logger zerolog.Logger
 }
 
-func NewZerolog(writer io.Writer) Logger {
+func NewZerolog(writer io.Writer, level string) Logger {
+	zlevel, err := zerolog.ParseLevel(level)
+	if err != nil {
+		zlevel = zerolog.InfoLevel
+	}
 	return &Zerolog{
-		logger: zerolog.New(zerolog.ConsoleWriter{Out: writer}).With().Timestamp().Logger(),
+		logger: zerolog.New(zerolog.ConsoleWriter{Out: writer}).Level(zlevel).With().Timestamp().Logger(),
 	}
 }
 

--- a/internal/log/zerolog_test.go
+++ b/internal/log/zerolog_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestZerolog_Info(t *testing.T) {
 	var buf bytes.Buffer
-	logger := NewZerolog(&buf)
+	logger := NewZerolog(&buf, "info")
 
 	logger.Info("This is an info message")
 
@@ -18,7 +18,7 @@ func TestZerolog_Info(t *testing.T) {
 
 func TestZerolog_Debug(t *testing.T) {
 	var buf bytes.Buffer
-	logger := NewZerolog(&buf)
+	logger := NewZerolog(&buf, "debug")
 
 	logger.Debug("This is a debug message")
 
@@ -27,7 +27,7 @@ func TestZerolog_Debug(t *testing.T) {
 
 func TestZerolog_Warn(t *testing.T) {
 	var buf bytes.Buffer
-	logger := NewZerolog(&buf)
+	logger := NewZerolog(&buf, "warn")
 
 	logger.Warn("This is a warning message")
 
@@ -36,7 +36,18 @@ func TestZerolog_Warn(t *testing.T) {
 
 func TestZerolog_Info_Parametrised(t *testing.T) {
 	var buf bytes.Buffer
-	logger := NewZerolog(&buf)
+	logger := NewZerolog(&buf, "info")
 	logger.Info("This is an info message with param: %d", 42)
 	assert.Contains(t, buf.String(), "This is an info message with param: 42", "Expected info message with parameter to be logged")
+}
+
+func TestZerolog_Unknown_UseInfoInstead(t *testing.T) {
+	var buf bytes.Buffer
+	logger := NewZerolog(&buf, "unknown")
+
+	logger.Debug("This is a debug message")
+	logger.Info("This is an info message")
+
+	assert.Contains(t, buf.String(), "This is an info message", "Expected info message to be logged")
+	assert.NotContains(t, buf.String(), "This is a debug message", "Expected debug message not to be logged")
 }

--- a/internal/output/editor.go
+++ b/internal/output/editor.go
@@ -27,7 +27,7 @@ func NewEditor(shell executor.Executor) *editor {
 		err:      os.Stderr,
 		in:       os.Stdin,
 		out:      os.Stdout,
-		log:      log.NewShort(log.NewZerolog(os.Stdout)),
+		log:      log.Get(),
 	}
 }
 


### PR DESCRIPTION
Adds `-q/--quiet` and `-d/--debug` flags to control log verbosity, replacing the need for `-v/--verbose`. Default logging remains at info level.

Closes #53