### PR TITLE
fix(#226): remove redundant command echo in aidy issue/pr execution

### DIFF
--- a/internal/output/editor.go
+++ b/internal/output/editor.go
@@ -66,9 +66,8 @@ func (e *editor) Print(command string) error {
 }
 
 func (e *editor) run(command string) error {
-	e.printf("running '%s' command\n", command)
+	e.printf("running...\n")
 	parts := cleanQoutes(splitCommand(command))
-	e.printf("command parts '%v'\n", parts)
 	_, err := e.shell.RunInteractively(parts[0], parts[1:]...)
 	if err != nil {
 		return err


### PR DESCRIPTION
Removes redundant command echo when running `aidy issue` or `aidy pr` commands.

Closes #226