### PR TITLE
docs(#224): Add go install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,20 @@ It helps generate commit messages, issues, pull requests, releases, and more.
 
 Download the latest stable version from the [releases page](https://github.com/volodya-lombrozo/aidy/releases). Pre-built binaries are available for MacOS, Windows, and Linux.
 
+### Using Go
+
+If you have Go 1.24.1 or later installed, you can run:
+
+```bash
+go install github.com/volodya-lombrozo/aidy@latest
+```
+
+To install a specific version, use:
+
+```bash
+go install github.com/volodya-lombrozo/aidy@v0.1.0
+```
+
 ### From Sources 
 
 You need to have Go 1.24.1 or later installed on your system.


### PR DESCRIPTION
Adds `go install` instructions to README for easier installation without cloning.

Closes #224