### PR TITLE
feat(#223): Add --fixes flag to control issue reference in PRs

### DIFF
--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -5,13 +5,15 @@ import (
 )
 
 func newPrCmd(ctx *Context) *cobra.Command {
+	fixes := false
 	command := &cobra.Command{
 		Use:     "pull-request",
 		Aliases: []string{"pr"},
 		Short:   "Create a PR based on changes in the current branch",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return ctx.Assistant.PullRequest()
+			return ctx.Assistant.PullRequest(fixes)
 		},
 	}
+	command.Flags().BoolVarP(&fixes, "fixes", "f", false, "Create a PR with 'fixes' keyword")
 	return command
 }

--- a/internal/ai/ai.go
+++ b/internal/ai/ai.go
@@ -4,7 +4,7 @@ import "fmt"
 
 type AI interface {
 	PrTitle(number string, diff string, issue string, summary string) (string, error)
-	PrBody(number string, diff string, issue string, summary string) (string, error)
+	PrBody(diff string, issue string, summary string) (string, error)
 	IssueTitle(input string, summary string) (string, error)
 	IssueBody(input string, summary string) (string, error)
 	IssueLabels(issue string, available []string) ([]string, error)

--- a/internal/ai/deepseek.go
+++ b/internal/ai/deepseek.go
@@ -57,8 +57,8 @@ func (d *DeepSeek) PrTitle(number, diff, issue, summary string) (string, error) 
 	return d.send("You are a helpful assistant generating Git commit titles.", prompt, summary)
 }
 
-func (d *DeepSeek) PrBody(number string, diff string, issue string, summary string) (string, error) {
-	prompt := fmt.Sprintf(PrBody, diff, issue, number)
+func (d *DeepSeek) PrBody(diff string, issue string, summary string) (string, error) {
+	prompt := fmt.Sprintf(PrBody, diff, issue)
 	return d.send("You are a helpful assistant generating Git commit messages.", prompt, summary)
 }
 

--- a/internal/ai/deepseek_test.go
+++ b/internal/ai/deepseek_test.go
@@ -65,9 +65,8 @@ func TestDeepSeekAI_PrBody(t *testing.T) {
 	ai.url = server.URL
 	expectedDiff := "Test diff"
 	expectedIssue := "Test issue"
-	expectedNumber := "42"
 
-	result, err := ai.PrBody(expectedNumber, expectedDiff, expectedIssue, "")
+	result, err := ai.PrBody(expectedDiff, expectedIssue, "")
 
 	require.NoError(t, err, "Expected no error when generating PR body")
 	assert.Contains(t, result, "generate a well-structured pull request body", "Echo server should return a command")

--- a/internal/ai/mock.go
+++ b/internal/ai/mock.go
@@ -28,8 +28,8 @@ func (m *MockAI) PrTitle(branchName string, diff string, issue string, summary s
 	return fmt.Sprintf("mock title for '%s' with issue #%s and summary: %s", branchName, issue, summary), nil
 }
 
-func (m *MockAI) PrBody(branch string, diff string, issue string, summary string) (string, error) {
-	return fmt.Sprintf("mock body for %s with issue #%s and summary: %s\n\ndiff:\n%s", branch, issue, summary, diff), nil
+func (m *MockAI) PrBody(diff string, issue string, summary string) (string, error) {
+	return fmt.Sprintf("mock body for issue #%s and summary: %s\n\ndiff:\n%s", issue, summary, diff), nil
 }
 
 func (m *MockAI) IssueTitle(input string, summary string) (string, error) {

--- a/internal/ai/mock_test.go
+++ b/internal/ai/mock_test.go
@@ -77,10 +77,8 @@ func TestMock_GenerateIssueBody(t *testing.T) {
 
 func TestMock_GenerateBody(t *testing.T) {
 	ai := NewMockAI()
-	branch := "feature-branch"
-	expected := fmt.Sprintf("mock body for %s with issue #issue and summary: summary\n\ndiff:\ndiff", branch)
-
-	body, err := ai.PrBody(branch, "diff", "issue", "summary")
+	expected := "mock body for issue #issue and summary: summary\n\ndiff:\ndiff"
+	body, err := ai.PrBody("diff", "issue", "summary")
 
 	require.NoError(t, err, "Expected no error")
 	assert.Contains(t, body, expected, "Expected body to match")

--- a/internal/ai/openai.go
+++ b/internal/ai/openai.go
@@ -42,8 +42,8 @@ func (o *OpenAI) PrTitle(number, diff, issue, summary string) (string, error) {
 	return o.send(prompt, summary)
 }
 
-func (o *OpenAI) PrBody(number, diff, issue, summary string) (string, error) {
-	prompt := fmt.Sprintf(PrBody, diff, issue, number)
+func (o *OpenAI) PrBody(diff, issue, summary string) (string, error) {
+	prompt := fmt.Sprintf(PrBody, diff, issue)
 	return o.send(prompt, summary)
 }
 

--- a/internal/ai/openai_test.go
+++ b/internal/ai/openai_test.go
@@ -57,7 +57,7 @@ func TestOpenAi_GeneratesTitleWithError(t *testing.T) {
 func TestOpenAi_GeneratesBody(t *testing.T) {
 	openai := NewOpenAIWithClient(NewEcho(), "test-model", 0.5, false)
 
-	body, err := openai.PrBody("123", "test diff", "successful issue-description", "project-summary")
+	body, err := openai.PrBody("test diff", "successful issue-description", "project-summary")
 
 	require.NoError(t, err, "Expected no error when generating PR body")
 	assert.Contains(t, body, "generate a well-structured pull request body", "Expected PR body to match mock response")

--- a/internal/ai/prompts.go
+++ b/internal/ai/prompts.go
@@ -50,11 +50,9 @@ The description must:
 - Avoid explaining why the changes were made.
 - Be approximately 50–100 characters long.
 - Use backticks for code or identifiers when appropriate.
-- End with an empty line followed by: "Closes #%s"
 
 Formatting rules:
 - Do not add section headers.
-- Do not include line breaks except before the "Closes" line.
 - Reply only with the pull request body — no additional text or explanations.
 `
 

--- a/internal/aidy/aidy.go
+++ b/internal/aidy/aidy.go
@@ -5,7 +5,7 @@ type Aidy interface {
 	PrintConfig() error
 	Commit() error
 	Squash()
-	PullRequest() error
+	PullRequest(fixes bool) error
 	Issue(task string) error
 	Heal() error
 	Append()

--- a/internal/aidy/mock.go
+++ b/internal/aidy/mock.go
@@ -29,7 +29,7 @@ func (m *Mock) Squash() {
 	m.logs = append(m.logs, "Squash called")
 }
 
-func (m *Mock) PullRequest() error {
+func (m *Mock) PullRequest(fixes bool) error {
 	m.logs = append(m.logs, "PullRequest called")
 	return nil
 }

--- a/internal/aidy/mock_test.go
+++ b/internal/aidy/mock_test.go
@@ -36,7 +36,7 @@ func TestMockAidy_Squash(t *testing.T) {
 
 func TestMockAidy_PullRequest(t *testing.T) {
 	aidy := NewMock()
-	err := aidy.PullRequest()
+	err := aidy.PullRequest(true)
 	require.NoError(t, err)
 	assert.Contains(t, aidy.Logs(), "PullRequest called")
 }


### PR DESCRIPTION
This PR changes the default PR reference from `Closes` to `Related to` and adds a `--fixes` flag to optionally close issues. The change provides more control over issue tracking behavior.

Fixes #223