### PR TITLE
fix(#220): ensure initial release versions match interval type

### DIFF
--- a/internal/aidy/real.go
+++ b/internal/aidy/real.go
@@ -469,7 +469,16 @@ func (r *real) Release(interval string, repo string) error {
 		}
 		r.logger.Info("latest tag is '%s', updating to '%s'", latest, updated)
 	} else {
-		updated = "v0.0.1"
+		switch interval {
+		case "patch":
+			updated = "v0.0.1"
+		case "minor":
+			updated = "v0.1.0"
+		case "major":
+			updated = "v1.0.0"
+		default:
+			return fmt.Errorf("unknown version step: '%s'", interval)
+		}
 		messages, err := r.git.Log("")
 		if err != nil {
 			return fmt.Errorf("failed to get git log: '%v'", err)

--- a/internal/aidy/real_test.go
+++ b/internal/aidy/real_test.go
@@ -676,7 +676,7 @@ func TestReal_Release_Success(t *testing.T) {
 	assert.Contains(t, out.Last(), expected, "expected release command to be generated")
 }
 
-func TestReal_Release_NoTags(t *testing.T) {
+func TestReal_Release_NoTags_Patch(t *testing.T) {
 	shell := executor.NewMock()
 	shell.Output = "absent"
 	output := output.NewMock()
@@ -688,6 +688,36 @@ func TestReal_Release_NoTags(t *testing.T) {
 
 	require.NoError(t, err, "expected no error when releasing with no tags")
 	expected := "git tag --cleanup=verbatim -a \"v0.0.1\" -m \""
+	assert.Contains(t, output.Last(), expected, "expected release command to be generated with no tags")
+}
+
+func TestReal_Release_NoTags_Minor(t *testing.T) {
+	shell := executor.NewMock()
+	shell.Output = "absent"
+	output := output.NewMock()
+	mockGit := git.NewMockWithShell(shell)
+
+	raidy := &real{git: mockGit, ai: ai.NewMockAI(), editor: output, logger: log.NewMock()}
+
+	err := raidy.Release("minor", "origin")
+
+	require.NoError(t, err, "expected no error when releasing with no tags")
+	expected := "git tag --cleanup=verbatim -a \"v0.1.0\" -m \""
+	assert.Contains(t, output.Last(), expected, "expected release command to be generated with no tags")
+}
+
+func TestReal_Release_NoTags_Major(t *testing.T) {
+	shell := executor.NewMock()
+	shell.Output = "absent"
+	output := output.NewMock()
+	mockGit := git.NewMockWithShell(shell)
+
+	raidy := &real{git: mockGit, ai: ai.NewMockAI(), editor: output, logger: log.NewMock()}
+
+	err := raidy.Release("major", "origin")
+
+	require.NoError(t, err, "expected no error when releasing with no tags")
+	expected := "git tag --cleanup=verbatim -a \"v1.0.0\" -m \""
 	assert.Contains(t, output.Last(), expected, "expected release command to be generated with no tags")
 }
 


### PR DESCRIPTION
Fixes version generation for initial releases to respect the specified interval (`patch`, `minor`, or `major`). Now `aidy release minor` starts at `0.1.0` and `aidy release major` at `1.0.0` when no tags exist.

Fixes #220