### PR TITLE
feat(#225): Add issue description context to commit messages

### DIFF
--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -5,12 +5,15 @@ import (
 )
 
 func newCommitCmd(ctx *Context) *cobra.Command {
-	return &cobra.Command{
+	var issue bool 
+	command := &cobra.Command{
 		Use:     "commit",
 		Aliases: []string{"ci"},
 		Short:   "Make a commit with AI-generated message",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return ctx.Assistant.Commit()
+			return ctx.Assistant.Commit(issue)
 		},
 	}
+	command.Flags().BoolVarP(&issue, "issue", "i", false, "use issue description to genearate commit message")
+	return command
 }

--- a/cmd/squash.go
+++ b/cmd/squash.go
@@ -5,13 +5,15 @@ import (
 )
 
 func newSquashCmd(ctx *Context) *cobra.Command {
+	var issue bool
 	command := &cobra.Command{
 		Use:     "squash",
 		Aliases: []string{"sq"},
 		Short:   "Squash all commits in the current branch into a single commit",
 		Run: func(cmd *cobra.Command, args []string) {
-			ctx.Assistant.Squash()
+			ctx.Assistant.Squash(issue)
 		},
 	}
+	command.Flags().BoolVarP(&issue, "issue", "i", false, "use issue description to genearate commit message")
 	return command
 }

--- a/internal/ai/ai.go
+++ b/internal/ai/ai.go
@@ -3,18 +3,18 @@ package ai
 import "fmt"
 
 type AI interface {
-	PrTitle(number string, diff string, issue string, summary string) (string, error)
-	PrBody(diff string, issue string, summary string) (string, error)
-	IssueTitle(input string, summary string) (string, error)
-	IssueBody(input string, summary string) (string, error)
+	PrTitle(number, diff, issue, summary string) (string, error)
+	PrBody(diff, issue, summary string) (string, error)
+	IssueTitle(input, summary string) (string, error)
+	IssueBody(input, summary string) (string, error)
 	IssueLabels(issue string, available []string) ([]string, error)
-	CommitMessage(number string, diff string) (string, error)
+	CommitMessage(number, diff, descr string) (string, error)
 	Summary(readme string) (string, error)
 	SuggestBranch(descr string) (string, error)
 	ReleaseNotes(changes string) (string, error)
 }
 
-func TrimPrompt(prompt string) string {
+func trimPrompt(prompt string) string {
 	limit := 120 * 400
 	runes := []rune(prompt)
 	if len(runes) > limit {
@@ -23,10 +23,18 @@ func TrimPrompt(prompt string) string {
 	return prompt
 }
 
-func AppendSummary(prompt, summary string) string {
+func appendSummary(prompt, summary string) string {
 	if summary == "" {
 		return prompt
 	}
 	appendix := fmt.Sprintf("\nThis is the project summary for which you do it:\n<summary>\n%s\n</summary>\n", summary)
+	return prompt + appendix
+}
+
+func appendIssue(prompt, description string) string {
+	if description == "" {
+		return prompt
+	}
+	appendix := fmt.Sprintf("\nThis is the issue description for which you do it:\n<issue>\n%s\n</issue>\n", description)
 	return prompt + appendix
 }

--- a/internal/ai/deepseek_test.go
+++ b/internal/ai/deepseek_test.go
@@ -126,7 +126,7 @@ func TestDeepSeekAI_CommitMessage(t *testing.T) {
 	expectedDiff := "Test diff"
 	expectedNumber := "42"
 
-	result, err := ai.CommitMessage(expectedNumber, expectedDiff)
+	result, err := ai.CommitMessage(expectedNumber, expectedDiff, "")
 
 	require.NoError(t, err, "Expected no error when generating commit message")
 	assert.Contains(t, result, "generate a single-line commit message", "Echo server should return a command")

--- a/internal/ai/mock.go
+++ b/internal/ai/mock.go
@@ -40,7 +40,7 @@ func (m *MockAI) IssueBody(input string, summary string) (string, error) {
 	return fmt.Sprintf("mock issue body for '%s' with summary: %s", input, summary), nil
 }
 
-func (m *MockAI) CommitMessage(issue string, diff string) (string, error) {
+func (m *MockAI) CommitMessage(issue, diff, descr string) (string, error) {
 	return fmt.Sprintf("feat(#%s): %s", issue, summary(diff)), nil
 }
 

--- a/internal/ai/mock_test.go
+++ b/internal/ai/mock_test.go
@@ -26,7 +26,7 @@ func TestMockGenerateCommitMessage(t *testing.T) {
 	issue := "100"
 	expected := fmt.Sprintf("feat(#%s): %s", issue, "changed files: ai/mockai.go")
 
-	msg, err := mockAI.CommitMessage(issue, diff)
+	msg, err := mockAI.CommitMessage(issue, diff, "")
 
 	require.NoError(t, err, "Expected no error")
 	assert.Equal(t, expected, msg, "Expected commit message to match")

--- a/internal/ai/openai.go
+++ b/internal/ai/openai.go
@@ -57,8 +57,8 @@ func (o *OpenAI) IssueBody(input string, summary string) (string, error) {
 	return o.send(prompt, summary)
 }
 
-func (o *OpenAI) CommitMessage(number, diff string) (string, error) {
-	prompt := fmt.Sprintf(CommitMsg, diff, number, number)
+func (o *OpenAI) CommitMessage(number, diff, descr string) (string, error) {
+	prompt := appendIssue(fmt.Sprintf(CommitMsg, diff, number, number), descr)
 	return o.send(prompt, "")
 }
 
@@ -95,9 +95,9 @@ func (o *OpenAI) SuggestBranch(descr string) (string, error) {
 func (o *OpenAI) send(prompt, summary string) (string, error) {
 	content := prompt
 	if o.summary {
-		content = AppendSummary(content, summary)
+		content = appendSummary(content, summary)
 	}
-	content = TrimPrompt(content)
+	content = trimPrompt(content)
 	req := openai.ChatCompletionRequest{
 		Model: o.model,
 		Messages: []openai.ChatCompletionMessage{

--- a/internal/ai/openai_test.go
+++ b/internal/ai/openai_test.go
@@ -132,7 +132,7 @@ func TestOpenAI_CommitMessage(t *testing.T) {
 	number := "123"
 	diff := "successful diff"
 
-	message, err := openAI.CommitMessage(number, diff)
+	message, err := openAI.CommitMessage(number, diff, "")
 
 	require.NoError(t, err, "Expected no error when generating commit message")
 	assert.Contains(t, message, diff, "Expected commit message to contain diff")

--- a/internal/aidy/aidy.go
+++ b/internal/aidy/aidy.go
@@ -1,10 +1,10 @@
 package aidy
 
 type Aidy interface {
-	Release(interval string, repo string) error
+	Release(interval, repo string) error
 	PrintConfig() error
-	Commit() error
-	Squash()
+	Commit(issue bool) error
+	Squash(issue bool)
 	PullRequest(fixes bool) error
 	Issue(task string) error
 	Heal() error

--- a/internal/aidy/mock.go
+++ b/internal/aidy/mock.go
@@ -20,12 +20,12 @@ func (m *Mock) PrintConfig() error {
 	return nil
 }
 
-func (m *Mock) Commit() error {
+func (m *Mock) Commit(issue bool) error {
 	m.logs = append(m.logs, "Commit called")
 	return nil
 }
 
-func (m *Mock) Squash() {
+func (m *Mock) Squash(issue bool) {
 	m.logs = append(m.logs, "Squash called")
 }
 

--- a/internal/aidy/mock_test.go
+++ b/internal/aidy/mock_test.go
@@ -23,14 +23,14 @@ func TestMockAidy_PrintConfig(t *testing.T) {
 
 func TestMockAidy_Commit(t *testing.T) {
 	aidy := NewMock()
-	err := aidy.Commit()
+	err := aidy.Commit(true)
 	require.NoError(t, err)
 	assert.Contains(t, aidy.Logs(), "Commit called")
 }
 
 func TestMockAidy_Squash(t *testing.T) {
 	aidy := NewMock()
-	aidy.Squash()
+	aidy.Squash(true)
 	assert.Contains(t, aidy.Logs(), "Squash called")
 }
 

--- a/internal/aidy/real_test.go
+++ b/internal/aidy/real_test.go
@@ -406,7 +406,7 @@ func TestReal_PrintConfig_NoConfig(t *testing.T) {
 
 func TestReal_Append(t *testing.T) {
 	shell := executor.NewMock()
-	raidy := &real{git: git.NewMockWithShell(shell), logger: log.Get()}
+	raidy := &real{git: git.NewMockWithShell(shell), logger: log.Default()}
 
 	raidy.Append()
 
@@ -469,7 +469,7 @@ func TestReal_CleanCache(t *testing.T) {
 	}()
 	err = os.Chdir(tmp)
 	require.NoError(t, err, "Failed to change working directory")
-	raidy := &real{logger: log.Get()}
+	raidy := &real{logger: log.Default()}
 
 	raidy.Clean()
 
@@ -481,7 +481,7 @@ func TestReal_StartIssue(t *testing.T) {
 	brain := ai.NewMockAI()
 	shell := executor.NewMock()
 	gh := github.NewMock()
-	raidy := &real{git: git.NewMockWithShell(shell), ai: brain, github: gh, logger: log.Get()}
+	raidy := &real{git: git.NewMockWithShell(shell), ai: brain, github: gh, logger: log.Default()}
 
 	err := raidy.StartIssue("42")
 
@@ -497,7 +497,7 @@ func TestReal_StartIssueNoNumber(t *testing.T) {
 	brain := ai.NewMockAI()
 	shell := executor.NewMock()
 	gh := github.NewMock()
-	raidy := &real{git: git.NewMockWithShell(shell), ai: brain, github: gh, logger: log.Get()}
+	raidy := &real{git: git.NewMockWithShell(shell), ai: brain, github: gh, logger: log.Default()}
 
 	err := raidy.StartIssue("")
 
@@ -509,7 +509,7 @@ func TestReal_StartIssueInvalidNumber(t *testing.T) {
 	brain := ai.NewMockAI()
 	shell := executor.NewMock()
 	gh := github.NewMock()
-	raidy := &real{git: git.NewMockWithShell(shell), ai: brain, github: gh, logger: log.Get()}
+	raidy := &real{git: git.NewMockWithShell(shell), ai: brain, github: gh, logger: log.Default()}
 
 	err := raidy.StartIssue("invalid")
 
@@ -521,7 +521,7 @@ func TestReal_StartIssueBranchNameError(t *testing.T) {
 	brain := ai.NewFailedMockAI()
 	shell := executor.NewMock()
 	gh := github.NewMock()
-	raidy := &real{git: git.NewMockWithShell(shell), ai: brain, github: gh, logger: log.Get()}
+	raidy := &real{git: git.NewMockWithShell(shell), ai: brain, github: gh, logger: log.Default()}
 
 	err := raidy.StartIssue("42")
 
@@ -533,7 +533,7 @@ func TestReal_StartIssueBranchNameError(t *testing.T) {
 func TestReal_StartIssueCheckoutError(t *testing.T) {
 	shell := executor.NewMock()
 	shell.Err = fmt.Errorf("error checking out branch")
-	raidy := &real{git: git.NewMockWithShell(shell), ai: ai.NewMockAI(), github: github.NewMock(), logger: log.Get()}
+	raidy := &real{git: git.NewMockWithShell(shell), ai: ai.NewMockAI(), github: github.NewMock(), logger: log.Default()}
 
 	err := raidy.StartIssue("42")
 
@@ -543,9 +543,9 @@ func TestReal_StartIssueCheckoutError(t *testing.T) {
 
 func TestReal_Squash(t *testing.T) {
 	shell := executor.NewMock()
-	raidy := &real{git: git.NewMockWithShell(shell), ai: ai.NewMockAI(), logger: log.Get()}
+	raidy := &real{github: github.NewMock(), git: git.NewMockWithShell(shell), ai: ai.NewMockAI(), logger: log.Default()}
 
-	raidy.Squash()
+	raidy.Squash(true)
 
 	expected := []string{
 		"git reset --soft refs/heads/main",
@@ -560,7 +560,7 @@ func TestReal_Squash(t *testing.T) {
 
 func TestReal_PullRequest(t *testing.T) {
 	out := output.NewMock()
-	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github.NewMock(), editor: out, cache: cache.NewMockAidyCache(), logger: log.Get()}
+	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github.NewMock(), editor: out, cache: cache.NewMockAidyCache(), logger: log.Default()}
 
 	err := raidy.PullRequest(false)
 
@@ -602,9 +602,9 @@ func TestReal_Commit(t *testing.T) {
 	brain := ai.NewMockAI()
 	shell := executor.NewMock()
 	mgit := git.NewMockWithShell(shell)
-	raidy := &real{git: mgit, ai: brain, logger: log.Get()}
+	raidy := &real{git: mgit, ai: brain, logger: log.Default(), github: github.NewMock()}
 
-	err := raidy.Commit()
+	err := raidy.Commit(true)
 
 	require.NoError(t, err, "expected no error when committing changes")
 	expected := []string{
@@ -620,18 +620,18 @@ func TestReal_Commit(t *testing.T) {
 func TestReal_Commit_CantGetCurrentBranch(t *testing.T) {
 	mgit := git.NewMockWithError(fmt.Errorf("CurrentBranch method fails"))
 
-	raidy := &real{git: mgit, ai: ai.NewMockAI(), logger: log.Get()}
+	raidy := &real{git: mgit, ai: ai.NewMockAI(), logger: log.Default()}
 
-	err := raidy.Commit()
+	err := raidy.Commit(true)
 	require.Error(t, err, "expected error when unable to get current branch")
 	assert.Equal(t, "error getting branch name: CurrentBranch method fails", err.Error(), "Expected error message to match")
 }
 
 func TestReal_Commit_CantGetCurrentDiff(t *testing.T) {
 	mgit := git.NewMockWithError(fmt.Errorf("CurrentDiff method fails"))
-	raidy := &real{git: mgit, ai: ai.NewMockAI(), logger: log.Get()}
+	raidy := &real{git: mgit, ai: ai.NewMockAI(), logger: log.Default()}
 
-	err := raidy.Commit()
+	err := raidy.Commit(true)
 
 	require.Error(t, err, "expected error when unable to get current diff")
 	assert.Equal(t, "error adding changes: CurrentDiff method fails", err.Error(), "Expected error message to match")
@@ -641,9 +641,9 @@ func TestReal_Commit_CantRunGit(t *testing.T) {
 	shell := executor.NewMock()
 	shell.Err = fmt.Errorf("git command failed")
 	mgit := git.NewMockWithShell(shell)
-	raidy := &real{git: mgit, ai: ai.NewMockAI(), logger: log.Get()}
+	raidy := &real{git: mgit, ai: ai.NewMockAI(), logger: log.Default()}
 
-	err := raidy.Commit()
+	err := raidy.Commit(true)
 
 	require.Error(t, err, "expected error when git command fails")
 	assert.Equal(t, "error adding changes: git command failed", err.Error(), "Expected error message to match")
@@ -652,7 +652,7 @@ func TestReal_Commit_CantRunGit(t *testing.T) {
 func TestReal_Issue(t *testing.T) {
 	userInput := "test input"
 	out := output.NewMock()
-	raidy := &real{ai: ai.NewMockAI(), github: github.NewMock(), editor: out, cache: cache.NewMockAidyCache(), logger: log.Get()}
+	raidy := &real{ai: ai.NewMockAI(), github: github.NewMock(), editor: out, cache: cache.NewMockAidyCache(), logger: log.Default()}
 
 	err := raidy.Issue(userInput)
 
@@ -884,7 +884,7 @@ func TestUpver(t *testing.T) {
 func TestInitLogger_DebugMode(t *testing.T) {
 	InitLogger(false, true)
 
-	logger := log.Get()
+	logger := log.Default()
 
 	assert.NotNil(t, logger, "Expected logger to be initialized")
 	assert.IsType(t, &log.Short{}, logger, "Expected logger to be of type Short")
@@ -893,7 +893,7 @@ func TestInitLogger_DebugMode(t *testing.T) {
 func TestInitLogger_SilentMode(t *testing.T) {
 	InitLogger(true, false)
 
-	logger := log.Get()
+	logger := log.Default()
 
 	assert.NotNil(t, logger, "Expected logger to be initialized")
 	assert.IsType(t, &log.Silent{}, logger, "Expected logger to be of type Silent")
@@ -902,7 +902,7 @@ func TestInitLogger_SilentMode(t *testing.T) {
 func TestInitLogger_DefaultMode(t *testing.T) {
 	InitLogger(false, false)
 
-	logger := log.Get()
+	logger := log.Default()
 
 	assert.NotNil(t, logger, "Expected logger to be initialized")
 	assert.IsType(t, &log.Short{}, logger, "Expected logger to be of type Short")

--- a/internal/executor/real.go
+++ b/internal/executor/real.go
@@ -21,7 +21,7 @@ func NewReal() Executor {
 		out: os.Stdout,
 		in:  os.Stdin,
 		err: os.Stderr,
-		log: log.Get(),
+		log: log.Default(),
 	}
 }
 

--- a/internal/executor/real_test.go
+++ b/internal/executor/real_test.go
@@ -34,7 +34,7 @@ func TestRealExecutor_RunCommandInDir(t *testing.T) {
 }
 
 func TestRealExecutor_RunInteractively(t *testing.T) {
-	executor := &RealExecutor{log: log.Get()}
+	executor := &RealExecutor{log: log.Default()}
 	r, w, err := os.Pipe()
 	require.NoError(t, err, "Failed to create pipe for stdout")
 	executor.out = w

--- a/internal/git/real.go
+++ b/internal/git/real.go
@@ -30,7 +30,7 @@ func NewGitFallback(shell executor.Executor, fallback func() (string, error), di
 			return nil, fmt.Errorf("failed to get current working directory: %w", err)
 		}
 	}
-	return &real{dir: directory, shell: shell, log: log.Get()}, nil
+	return &real{dir: directory, shell: shell, log: log.Default()}, nil
 }
 
 func (r *real) Run(arg ...string) (string, error) {

--- a/internal/github/real.go
+++ b/internal/github/real.go
@@ -44,7 +44,7 @@ func NewGithub(url string, gs git.Git, token string, ch cache.AidyCache) *github
 		git:    gs,
 		token:  token,
 		ch:     ch,
-		log:    log.Get(),
+		log:    log.Default(),
 	}
 }
 

--- a/internal/log/logger.go
+++ b/internal/log/logger.go
@@ -18,7 +18,7 @@ func Set(logger Logger) {
 	main = logger
 }
 
-func Get() Logger {
+func Default() Logger {
 	if main == nil {
 		panic("logger is not set")
 	}

--- a/internal/log/logger_test.go
+++ b/internal/log/logger_test.go
@@ -11,7 +11,7 @@ func TestSetAndGetLogger(t *testing.T) {
 	mock := NewMock()
 	Set(mock)
 
-	initialised := Get()
+	initialised := Default()
 
 	assert.Equal(t, mock, initialised, "Expected retrieved logger to be the mock logger")
 }
@@ -29,6 +29,6 @@ func TestGetLoggerNotSetPanics(t *testing.T) {
 	}()
 	main = nil
 	require.Panics(t, func() {
-		Get()
+		Default()
 	}, "Expected panic when getting logger that is not set")
 }

--- a/internal/output/editor.go
+++ b/internal/output/editor.go
@@ -27,7 +27,7 @@ func NewEditor(shell executor.Executor) *editor {
 		err:      os.Stderr,
 		in:       os.Stdin,
 		out:      os.Stdout,
-		log:      log.Get(),
+		log:      log.Default(),
 	}
 }
 


### PR DESCRIPTION
This PR adds support for including issue descriptions when generating commit messages via the `commit` and `squash` commands using the new `-i` flag.

Fixes #225