### PR TITLE
fix(#270): allow commands to run without GitHub when remote is not GitHub

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,8 +20,8 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version: '1.24'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.1.0

--- a/internal/aidy/real.go
+++ b/internal/aidy/real.go
@@ -77,9 +77,6 @@ func NewAidy(summary bool, aider bool, ailess bool, silent bool, debug bool) Aid
 	if err = aidy.InitSummary(summary, "README.md"); err != nil {
 		aidy.logger.Warn("failed to initialize project summary: %v", err)
 	}
-	if err = aidy.SetTarget(); err != nil {
-		aidy.logger.Warn("failed to set target repository: %v", err)
-	}
 	return &aidy
 }
 
@@ -166,6 +163,19 @@ func (r *real) Commit(issue bool) error {
 	if err != nil {
 		return fmt.Errorf("error getting branch name: %v", err)
 	}
+	nissue := inumber(branch)
+	var descr string
+	if issue {
+		if err = r.SetTarget(); err != nil {
+			r.logger.Warn("failed to set target repository: %v", err)
+		}
+		descr, err = r.github.Description(nissue)
+		if err != nil {
+			return fmt.Errorf("error retrieving issue description: %v", err)
+		}
+	} else {
+		descr = ""
+	}
 	_, err = r.git.Run("add", "--all")
 	if err != nil {
 		return fmt.Errorf("error adding changes: %v", err)
@@ -174,17 +184,7 @@ func (r *real) Commit(issue bool) error {
 	if diffErr != nil {
 		return fmt.Errorf("error getting current diff: %v", diffErr)
 	}
-	nissue := inumber(branch)
 	r.logger.Info("generating commit message...")
-	var descr string
-	if issue {
-		descr, err = r.github.Description(nissue)
-		if err != nil {
-			return fmt.Errorf("error retrieving issue description: %v", err)
-		}
-	} else {
-		descr = ""
-	}
 	msg, cerr := r.ai.CommitMessage(nissue, diff, descr)
 	if cerr != nil {
 		return fmt.Errorf("error generating commit message: %v", cerr)
@@ -198,6 +198,9 @@ func (r *real) Commit(issue bool) error {
 }
 
 func (r *real) Issue(task string) error {
+	if err := r.SetTarget(); err != nil {
+		r.logger.Warn("failed to set target repository: %v", err)
+	}
 	summary, _ := r.cache.Summary()
 	r.logger.Info("generating issue title...")
 	title, err := r.ai.IssueTitle(task, summary)
@@ -326,6 +329,9 @@ func (r *real) print(msg string) {
 }
 
 func (r *real) PullRequest(fixes bool) error {
+	if err := r.SetTarget(); err != nil {
+		r.logger.Warn("failed to set target repository: %v", err)
+	}
 	branch, err := r.git.CurrentBranch()
 	if err != nil {
 		return fmt.Errorf("error getting branch name: %v", err)
@@ -414,6 +420,9 @@ func (r *real) Clean() {
 }
 
 func (r *real) StartIssue(number string) error {
+	if err := r.SetTarget(); err != nil {
+		r.logger.Warn("failed to set target repository: %v", err)
+	}
 	if number == "" {
 		return fmt.Errorf("error: no issue number provided")
 	}

--- a/internal/aidy/real_test.go
+++ b/internal/aidy/real_test.go
@@ -481,7 +481,7 @@ func TestReal_StartIssue(t *testing.T) {
 	brain := ai.NewMockAI()
 	shell := executor.NewMock()
 	gh := github.NewMock()
-	raidy := &real{git: git.NewMockWithShell(shell), ai: brain, github: gh, logger: log.Default()}
+	raidy := &real{git: git.NewMockWithShell(shell), ai: brain, github: gh, cache: cache.NewMockAidyCache(), logger: log.Default()}
 
 	err := raidy.StartIssue("42")
 
@@ -497,7 +497,7 @@ func TestReal_StartIssueNoNumber(t *testing.T) {
 	brain := ai.NewMockAI()
 	shell := executor.NewMock()
 	gh := github.NewMock()
-	raidy := &real{git: git.NewMockWithShell(shell), ai: brain, github: gh, logger: log.Default()}
+	raidy := &real{git: git.NewMockWithShell(shell), ai: brain, github: gh, cache: cache.NewMockAidyCache(), logger: log.Default()}
 
 	err := raidy.StartIssue("")
 
@@ -509,7 +509,7 @@ func TestReal_StartIssueInvalidNumber(t *testing.T) {
 	brain := ai.NewMockAI()
 	shell := executor.NewMock()
 	gh := github.NewMock()
-	raidy := &real{git: git.NewMockWithShell(shell), ai: brain, github: gh, logger: log.Default()}
+	raidy := &real{git: git.NewMockWithShell(shell), ai: brain, github: gh, cache: cache.NewMockAidyCache(), logger: log.Default()}
 
 	err := raidy.StartIssue("invalid")
 
@@ -521,7 +521,7 @@ func TestReal_StartIssueBranchNameError(t *testing.T) {
 	brain := ai.NewFailedMockAI()
 	shell := executor.NewMock()
 	gh := github.NewMock()
-	raidy := &real{git: git.NewMockWithShell(shell), ai: brain, github: gh, logger: log.Default()}
+	raidy := &real{git: git.NewMockWithShell(shell), ai: brain, github: gh, cache: cache.NewMockAidyCache(), logger: log.Default()}
 
 	err := raidy.StartIssue("42")
 
@@ -533,7 +533,7 @@ func TestReal_StartIssueBranchNameError(t *testing.T) {
 func TestReal_StartIssueCheckoutError(t *testing.T) {
 	shell := executor.NewMock()
 	shell.Err = fmt.Errorf("error checking out branch")
-	raidy := &real{git: git.NewMockWithShell(shell), ai: ai.NewMockAI(), github: github.NewMock(), logger: log.Default()}
+	raidy := &real{git: git.NewMockWithShell(shell), ai: ai.NewMockAI(), github: github.NewMock(), cache: cache.NewMockAidyCache(), logger: log.Default()}
 
 	err := raidy.StartIssue("42")
 
@@ -543,7 +543,7 @@ func TestReal_StartIssueCheckoutError(t *testing.T) {
 
 func TestReal_Squash(t *testing.T) {
 	shell := executor.NewMock()
-	raidy := &real{github: github.NewMock(), git: git.NewMockWithShell(shell), ai: ai.NewMockAI(), logger: log.Default()}
+	raidy := &real{github: github.NewMock(), git: git.NewMockWithShell(shell), ai: ai.NewMockAI(), cache: cache.NewMockAidyCache(), logger: log.Default()}
 
 	raidy.Squash(true)
 
@@ -602,7 +602,7 @@ func TestReal_Commit(t *testing.T) {
 	brain := ai.NewMockAI()
 	shell := executor.NewMock()
 	mgit := git.NewMockWithShell(shell)
-	raidy := &real{git: mgit, ai: brain, logger: log.Default(), github: github.NewMock()}
+	raidy := &real{git: mgit, ai: brain, logger: log.Default(), github: github.NewMock(), cache: cache.NewMockAidyCache()}
 
 	err := raidy.Commit(true)
 
@@ -620,7 +620,7 @@ func TestReal_Commit(t *testing.T) {
 func TestReal_Commit_CantGetCurrentBranch(t *testing.T) {
 	mgit := git.NewMockWithError(fmt.Errorf("CurrentBranch method fails"))
 
-	raidy := &real{git: mgit, ai: ai.NewMockAI(), logger: log.Default()}
+	raidy := &real{git: mgit, ai: ai.NewMockAI(), logger: log.Default(), cache: cache.NewMockAidyCache()}
 
 	err := raidy.Commit(true)
 	require.Error(t, err, "expected error when unable to get current branch")
@@ -629,7 +629,7 @@ func TestReal_Commit_CantGetCurrentBranch(t *testing.T) {
 
 func TestReal_Commit_CantGetCurrentDiff(t *testing.T) {
 	mgit := git.NewMockWithError(fmt.Errorf("CurrentDiff method fails"))
-	raidy := &real{git: mgit, ai: ai.NewMockAI(), logger: log.Default()}
+	raidy := &real{git: mgit, ai: ai.NewMockAI(), logger: log.Default(), cache: cache.NewMockAidyCache(), github: github.NewMock()}
 
 	err := raidy.Commit(true)
 
@@ -641,7 +641,7 @@ func TestReal_Commit_CantRunGit(t *testing.T) {
 	shell := executor.NewMock()
 	shell.Err = fmt.Errorf("git command failed")
 	mgit := git.NewMockWithShell(shell)
-	raidy := &real{git: mgit, ai: ai.NewMockAI(), logger: log.Default()}
+	raidy := &real{git: mgit, ai: ai.NewMockAI(), logger: log.Default(), cache: cache.NewMockAidyCache(), github: github.NewMock()}
 
 	err := raidy.Commit(true)
 


### PR DESCRIPTION
This PR updates the `aidy` commands to allow execution without GitHub access when the remote is not GitHub.

Fixes #270