### PR TITLE
fix(#273): prevent creation of cache file unless data is written

### DIFF
--- a/internal/cache/file.go
+++ b/internal/cache/file.go
@@ -18,19 +18,7 @@ func NewFileCache(path string) (Cache, error) {
 	fcache := &fileCache{path: path, store: map[string]string{}}
 	file, err := os.Open(path)
 	if err != nil {
-		if os.IsNotExist(err) {
-			dir := filepath.Dir(path)
-			if mkerr := os.MkdirAll(dir, 0755); mkerr != nil {
-				return nil, mkerr
-			}
-			created, cerr := os.Create(path)
-			if cerr != nil {
-				return nil, cerr
-			}
-			if cerr := created.Close(); cerr != nil {
-				return nil, cerr
-			}
-		} else {
+		if !os.IsNotExist(err) {
 			return nil, err
 		}
 	} else {

--- a/internal/cache/file_test.go
+++ b/internal/cache/file_test.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"os"
+	"path/filepath"
 	"runtime"
 	"testing"
 
@@ -79,6 +80,31 @@ func TestFileCache_Overwrites(t *testing.T) {
 	val, _ := cache.Get("k")
 
 	assert.Equal(t, "v2", val, "Expected value to be overwritten to 'v2'")
+}
+
+func TestFileCache_DoesNotCreateFileWhenNoDataWritten(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cache.json")
+
+	_, err := NewFileCache(path)
+	require.NoError(t, err)
+
+	_, serr := os.Stat(path)
+	assert.True(t, os.IsNotExist(serr), "Cache file must not be created until data is written")
+}
+
+func TestFileCache_CreatesFileOnlyOnFirstWrite(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cache.json")
+
+	c, err := NewFileCache(path)
+	require.NoError(t, err)
+
+	_, serr := os.Stat(path)
+	require.True(t, os.IsNotExist(serr), "Cache file must not exist before any writes")
+
+	require.NoError(t, c.Set("key", "value"))
+
+	_, serr = os.Stat(path)
+	assert.NoError(t, serr, "Cache file must be created after the first write")
 }
 
 func temp(t *testing.T) string {

--- a/internal/cache/git_test.go
+++ b/internal/cache/git_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/volodya-lombrozo/aidy/internal/git"
 )
 
-func TestNewGitCache_CreatesFileIfNotExists(t *testing.T) {
+func TestNewGitCache_DoesNotCreateFileWhenNoDataWritten(t *testing.T) {
 	tmp := t.TempDir()
 	defer clean(t, tmp)
 	name := "cache.json"
@@ -20,8 +20,8 @@ func TestNewGitCache_CreatesFileIfNotExists(t *testing.T) {
 	_, err := NewGitCache(name, git.NewMockWithDir(tmp))
 
 	assert.NoError(t, err, "Expected no error when creating GitCache with a new file path")
-	_, err = os.Stat(file)
-	assert.NoError(t, err, "Expected file to be created")
+	_, serr := os.Stat(file)
+	assert.True(t, os.IsNotExist(serr), "Cache file must not be created until data is written")
 }
 
 func TestGitCache_RootError(t *testing.T) {


### PR DESCRIPTION
This PR prevents the creation of the `.aidy/cache.js` file until data is written.

Fixes #273