### PR TITLE
feat(#272): Support commit generation for branches with conventional tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ Example output:
 Commit created with message: 'docs(#209): Update README with installation and configuration details'
 ```
 
+or if you a using JIRA-sytle branches:
+
+```
+Commit created with message: 'docs(PROJ-209): Update README with installation and configuration details'
+```
+
 Shorter version is `aidy ci`.
 
 ### Pull Request

--- a/internal/ai/mock.go
+++ b/internal/ai/mock.go
@@ -41,7 +41,7 @@ func (m *MockAI) IssueBody(input string, summary string) (string, error) {
 }
 
 func (m *MockAI) CommitMessage(issue, diff, descr string) (string, error) {
-	return fmt.Sprintf("feat(#%s): %s", issue, summary(diff)), nil
+	return fmt.Sprintf("feat(%s): %s", issue, summary(diff)), nil
 }
 
 func (m *MockAI) IssueLabels(issue string, available []string) ([]string, error) {

--- a/internal/ai/mock_test.go
+++ b/internal/ai/mock_test.go
@@ -23,8 +23,8 @@ index 97c5ff0..2eea6a0 100644
 
 func TestMockGenerateCommitMessage(t *testing.T) {
 	mockAI := NewMockAI()
-	issue := "100"
-	expected := fmt.Sprintf("feat(#%s): %s", issue, "changed files: ai/mockai.go")
+	issue := "#100"
+	expected := fmt.Sprintf("feat(%s): %s", issue, "changed files: ai/mockai.go")
 
 	msg, err := mockAI.CommitMessage(issue, diff, "")
 

--- a/internal/ai/prompts.go
+++ b/internal/ai/prompts.go
@@ -17,10 +17,10 @@ This pull request addresses the following issue:
 
 Carefully review both the diff and the issue description. Then, generate a PR title in the following format:
 
-<type>(#%s): <description>
+<type>(%s): <description>
 
 - Valid <type> values: fix, feat, build, chore, ci, docs, style, refactor, perf, test.
-- Always include the issue number #%s in the title.
+- Always include the issue reference %s in the title.
 - Use the imperative mood (e.g., "add feature", not "added feature" or "adding feature").
 - Keep the title within 72 characters.
 - Do not include explanations, comments, or line breaks. Return only the title line.
@@ -67,11 +67,11 @@ Your task is to generate a single-line commit message for the following changes.
 Review diffs carefully.
 
 The commit message must follow this format:
-<type>(#%s): <description>
+<type>(%s): <description>
 
 Where:
 - <type> is one of: fix, feat, build, chore, ci, docs, style, refactor, perf, test
-- #%s is the issue number (do not modify it)
+- %s is the issue reference (do not modify it)
 
 Ensure the message:
 - Starts with the appropriate prefix

--- a/internal/aidy/real.go
+++ b/internal/aidy/real.go
@@ -164,6 +164,7 @@ func (r *real) Commit(issue bool) error {
 		return fmt.Errorf("error getting branch name: %v", err)
 	}
 	nissue := inumber(branch)
+	r.logger.Info("retrieving the description for issue #%s...", nissue)
 	var descr string
 	if issue {
 		if err = r.SetTarget(); err != nil {
@@ -184,8 +185,9 @@ func (r *real) Commit(issue bool) error {
 	if diffErr != nil {
 		return fmt.Errorf("error getting current diff: %v", diffErr)
 	}
-	r.logger.Info("generating commit message...")
-	msg, cerr := r.ai.CommitMessage(nissue, diff, descr)
+	iref := issueRef(nissue)
+	r.logger.Info("generating commit message for %s...", iref)
+	msg, cerr := r.ai.CommitMessage(iref, diff, descr)
 	if cerr != nil {
 		return fmt.Errorf("error generating commit message: %v", cerr)
 	}
@@ -272,12 +274,12 @@ func healQuote(open rune, text string) string {
 }
 
 func healPRTitle(text string, issue string) string {
-	re := regexp.MustCompile(`(fix|feat|build|chore|ci|docs|style|refactor|perf|test)\(#(\d+)\)`)
+	re := regexp.MustCompile(`(fix|feat|build|chore|ci|docs|style|refactor|perf|test)\((?:#?\d+|#?[A-Z][A-Z0-9]+-\d+)\)`)
 	replaced := re.ReplaceAllStringFunc(text, func(m string) string {
 		groups := re.FindStringSubmatch(m)
-		if len(groups) == 3 {
+		if len(groups) >= 2 {
 			commitType := groups[1]
-			return fmt.Sprintf("%s(#%s)", commitType, issue)
+			return fmt.Sprintf("%s(%s)", commitType, issueRef(issue))
 		}
 		return m
 	})
@@ -349,7 +351,7 @@ func (r *real) PullRequest(fixes bool) error {
 		r.logger.Warn("issue description not found for issue #%s because of %v, using default value", nissue, err)
 	}
 	r.logger.Info("generating pull request title...")
-	title, err := r.ai.PrTitle(nissue, diff, issue, summary)
+	title, err := r.ai.PrTitle(issueRef(nissue), diff, issue, summary)
 	if err != nil {
 		return fmt.Errorf("error generating pull request title: %v", err)
 	}
@@ -359,9 +361,9 @@ func (r *real) PullRequest(fixes bool) error {
 		return fmt.Errorf("error generating pull request body: %v", err)
 	}
 	if fixes {
-		body = body + fmt.Sprintf("\n\nFixes #%s", nissue)
+		body = body + fmt.Sprintf("\n\nFixes %s", issueRef(nissue))
 	} else {
-		body = body + fmt.Sprintf("\n\nRelated to #%s", nissue)
+		body = body + fmt.Sprintf("\n\nRelated to %s", issueRef(nissue))
 	}
 	remote := r.cache.Remote()
 	var repo string
@@ -384,6 +386,9 @@ func inumber(branch string) string {
 		parts := strings.Split(branch, "/")
 		branch = parts[len(parts)-1]
 	}
+	if found := regexp.MustCompile(`^[A-Z][A-Z0-9]+-\d+`).FindString(branch); found != "" {
+		return found
+	}
 	re, err := regexp.Compile(`\d+`)
 	if err != nil {
 		panic(err)
@@ -393,6 +398,13 @@ func inumber(branch string) string {
 		return branch
 	}
 	return found
+}
+
+func issueRef(id string) string {
+	if regexp.MustCompile(`^\d+$`).MatchString(id) {
+		return "#" + id
+	}
+	return id
 }
 
 func (r *real) Append() {
@@ -593,8 +605,8 @@ func (r *real) Heal() error {
 	if gitErr != nil {
 		return fmt.Errorf("error getting current commit message: %v", gitErr)
 	}
-	re := regexp.MustCompile(`#\d+`)
-	updated := re.ReplaceAllString(message, fmt.Sprintf("#%s", inumber))
+	re := regexp.MustCompile(`#\d+|[A-Z][A-Z0-9]+-\d+`)
+	updated := re.ReplaceAllString(message, issueRef(inumber))
 	err = r.git.Amend(updated)
 	return err
 }

--- a/internal/aidy/real_test.go
+++ b/internal/aidy/real_test.go
@@ -567,7 +567,7 @@ func TestReal_PullRequest(t *testing.T) {
 	require.NoError(t, err, "expected no error when creating pull request")
 	output := out.Last()
 	assert.Contains(t, output, "gh pr create", "Expected output to contain 'gh pr create'")
-	assert.Contains(t, output, "--title \"mock title for '41' with issue #mock description for issue '#41' and summary: mock summary\"", "Expected output to contain title")
+	assert.Contains(t, output, "--title \"mock title for '#41' with issue #mock description for issue '#41' and summary: mock summary\"", "Expected output to contain title")
 }
 
 func TestReal_PullRequest_IssueNotFound(t *testing.T) {
@@ -817,6 +817,11 @@ func TestExtractIssueNumber(t *testing.T) {
 		{"spike/777-redesign-login-flow", "777"},
 		{"quickfix-4202-crash-on-load", "4202"},
 		{"ticket_900-improve-ci-speed", "900"},
+		{"bug/PROJ-42", "PROJ-42"},
+		{"feature/PROJ-17", "PROJ-17"},
+		{"fix/ISSUE-100", "ISSUE-100"},
+		{"chore/AB-99-cleanup", "AB-99"},
+		{"feature/proj-42", "42"},
 	}
 
 	for _, test := range tests {
@@ -850,6 +855,20 @@ func TestHealPRTitle(t *testing.T) {
 	}
 	for _, test := range tests {
 		result := healPRTitle(test.actual, "42")
+		assert.Equal(t, test.expected, result)
+	}
+
+	alphanumericTests := []struct {
+		actual   string
+		expected string
+	}{
+		{"feat(#7523): Add feature", "feat(PROJ-17): Add feature"},
+		{"feat(PROJ-99): Add feature", "feat(PROJ-17): Add feature"},
+		{"fix(#7523): Fix bug", "fix(PROJ-17): Fix bug"},
+		{"feat(#master): no change", "feat(#master): no change"},
+	}
+	for _, test := range alphanumericTests {
+		result := healPRTitle(test.actual, "PROJ-17")
 		assert.Equal(t, test.expected, result)
 	}
 }


### PR DESCRIPTION
This PR enhances commit message generation to support branches with conventional tags like `bug/PROJ-42`, formatting messages as `bug(PROJ-42): msg`.

Fixes #272