### PR TITLE
feat(#279): add Anthropic provider support alongside OpenAI and DeepSeek

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,22 @@ models:
     model-id: gpt-4o 
 ```
 
-Only `deepseek` and `openai` providers are supported. Verify the configuration with:
+For Anthropic:
+
+```yaml
+default-model: claude-sonnet
+
+api-keys:
+  github: <github-key>
+  anthropic: <anthropic-key>
+
+models:
+  claude-sonnet:
+    provider: anthropic
+    model-id: claude-sonnet-4-6
+```
+
+Supported providers: `deepseek`, `openai`, and `anthropic`. Verify the configuration with:
 
 ```bash
 aidy conf

--- a/internal/ai/anthropic.go
+++ b/internal/ai/anthropic.go
@@ -1,0 +1,156 @@
+package ai
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/volodya-lombrozo/aidy/internal/log"
+)
+
+const anthropicDefaultModel = "claude-sonnet-4-6"
+const anthropicVersion = "2023-06-01"
+
+type Anthropic struct {
+	token   string
+	url     string
+	model   string
+	summary bool
+	log     log.Logger
+}
+
+type anthropicRequest struct {
+	Model     string        `json:"model"`
+	MaxTokens int           `json:"max_tokens"`
+	System    string        `json:"system"`
+	Messages  []chatMessage `json:"messages"`
+}
+
+type anthropicContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type anthropicResponse struct {
+	Content []anthropicContent `json:"content"`
+}
+
+func NewAnthropic(token, model string, summary bool) AI {
+	if model == "" {
+		model = anthropicDefaultModel
+	}
+	return &Anthropic{
+		token:   token,
+		url:     "https://api.anthropic.com/v1/messages",
+		model:   model,
+		summary: summary,
+		log:     log.Default(),
+	}
+}
+
+func (a *Anthropic) ReleaseNotes(changes string) (string, error) {
+	prompt := fmt.Sprintf(ReleaseNotes, changes)
+	return a.send("You are a helpful assistant generating GitHub release notes.", prompt, "")
+}
+
+func (a *Anthropic) PrTitle(number, diff, issue, summary string) (string, error) {
+	prompt := fmt.Sprintf(PrTitle, diff, issue, number, number)
+	return a.send("You are a helpful assistant generating Git commit titles.", prompt, summary)
+}
+
+func (a *Anthropic) PrBody(diff string, issue string, summary string) (string, error) {
+	prompt := fmt.Sprintf(PrBody, diff, issue)
+	return a.send("You are a helpful assistant generating Git commit messages.", prompt, summary)
+}
+
+func (a *Anthropic) IssueTitle(userInput string, summary string) (string, error) {
+	prompt := fmt.Sprintf(IssueTitle, userInput)
+	return a.send("You are a helpful assistant creating GitHub issue titles.", prompt, summary)
+}
+
+func (a *Anthropic) IssueBody(input string, summary string) (string, error) {
+	prompt := fmt.Sprintf(IssueBody, input)
+	return a.send("You are a helpful assistant writing GitHub issue descriptions.", prompt, summary)
+}
+
+func (a *Anthropic) IssueLabels(issue string, available []string) ([]string, error) {
+	alllabels := strings.Join(available, ", ")
+	prompt := fmt.Sprintf(Labels, issue, alllabels)
+	resp, err := a.send("You are a helpful assistant assigning GitHub issue labels.", prompt, "")
+	if err != nil {
+		return nil, err
+	}
+	var res []string
+	for _, label := range available {
+		if strings.Contains(resp, label) {
+			res = append(res, label)
+		}
+	}
+	return res, nil
+}
+
+func (a *Anthropic) CommitMessage(number, diff, descr string) (string, error) {
+	prompt := appendIssue(fmt.Sprintf(CommitMsg, diff, number, number), descr)
+	a.log.Debug("anthropic prompt: %q", prompt)
+	return a.send("You are a helpful assistant writing commit messages.", prompt, "")
+}
+
+func (a *Anthropic) Summary(readme string) (string, error) {
+	prompt := fmt.Sprintf(Summary, readme)
+	return a.send("You are a helpful assistant writing project summaries.", prompt, "")
+}
+
+func (a *Anthropic) SuggestBranch(descr string) (string, error) {
+	prompt := fmt.Sprintf(BranchName, descr)
+	return a.send("You are a helpful assistant suggesting branch names.", prompt, "")
+}
+
+func (a *Anthropic) send(system, user, summary string) (string, error) {
+	content := user
+	if a.summary {
+		content = appendSummary(content, summary)
+	}
+	content = trimPrompt(content)
+	body := anthropicRequest{
+		Model:     a.model,
+		MaxTokens: 1024,
+		System:    system,
+		Messages:  []chatMessage{{Role: "user", Content: content}},
+	}
+	data, err := json.Marshal(body)
+	if err != nil {
+		return "", err
+	}
+	req, err := http.NewRequest("POST", a.url, bytes.NewBuffer(data))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", a.token)
+	req.Header.Set("anthropic-version", anthropicVersion)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("error making request to anthropic api: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			a.log.Error("error closing response body: %v", err)
+		}
+	}()
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("API error: %s", body)
+	}
+	var parsed anthropicResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return "", fmt.Errorf("error decoding response: %w", err)
+	}
+	if len(parsed.Content) == 0 {
+		return "", errors.New("no content in response")
+	}
+	return strings.TrimSpace(parsed.Content[0].Text), nil
+}

--- a/internal/ai/anthropic_test.go
+++ b/internal/ai/anthropic_test.go
@@ -191,7 +191,6 @@ func anthropicEchoServer(t *testing.T) *httptest.Server {
 }
 
 func replaceChars(s string) string {
-	s = fmt.Sprintf("%s", s)
 	result := make([]byte, 0, len(s))
 	for i := 0; i < len(s); i++ {
 		switch s[i] {

--- a/internal/ai/anthropic_test.go
+++ b/internal/ai/anthropic_test.go
@@ -1,0 +1,207 @@
+package ai
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnthropicAI_Summary(t *testing.T) {
+	server := anthropicEchoServer(t)
+	defer server.Close()
+	ai := NewAnthropic("test-token", "", true).(*Anthropic)
+	ai.url = server.URL
+	expected := "Test README content"
+
+	result, err := ai.Summary(expected)
+
+	require.NoError(t, err, "Expected no error when generating summary")
+	assert.Contains(t, result, "generate a short, single-paragraph summary", "Echo server should return a command")
+	assert.Contains(t, result, expected, "Expected summary to contain README content")
+}
+
+func TestAnthropicAI_ReleaseNotes(t *testing.T) {
+	server := anthropicEchoServer(t)
+	defer server.Close()
+	ai := NewAnthropic("test-token", "", false).(*Anthropic)
+	ai.url = server.URL
+	expected := "Test changes"
+
+	result, err := ai.ReleaseNotes(expected)
+
+	require.NoError(t, err, "Expected no error when generating release notes")
+	assert.Contains(t, result, "Generate clear, concise release notes", "Echo server should return a command")
+	assert.Contains(t, result, expected, "Expected release notes to contain changes")
+}
+
+func TestAnthropicAI_PrTitle(t *testing.T) {
+	server := anthropicEchoServer(t)
+	defer server.Close()
+	ai := NewAnthropic("test-token", "", true).(*Anthropic)
+	ai.url = server.URL
+	expectedDiff := "Test diff"
+	expectedIssue := "Test issue"
+	expectedNumber := "42"
+
+	result, err := ai.PrTitle(expectedNumber, expectedDiff, expectedIssue, "")
+
+	require.NoError(t, err, "Expected no error when generating PR title")
+	assert.Contains(t, result, "generate a one-line PR title", "Echo server should return a command")
+	assert.Contains(t, result, expectedDiff, "Expected PR title to contain diff")
+	assert.Contains(t, result, expectedIssue, "Expected PR title to contain issue")
+}
+
+func TestAnthropicAI_PrBody(t *testing.T) {
+	server := anthropicEchoServer(t)
+	defer server.Close()
+	ai := NewAnthropic("test-token", "", true).(*Anthropic)
+	ai.url = server.URL
+	expectedDiff := "Test diff"
+	expectedIssue := "Test issue"
+
+	result, err := ai.PrBody(expectedDiff, expectedIssue, "")
+
+	require.NoError(t, err, "Expected no error when generating PR body")
+	assert.Contains(t, result, "generate a well-structured pull request body", "Echo server should return a command")
+	assert.Contains(t, result, expectedDiff, "Expected PR body to contain diff")
+	assert.Contains(t, result, expectedIssue, "Expected PR body to contain issue")
+}
+
+func TestAnthropicAI_IssueTitle(t *testing.T) {
+	server := anthropicEchoServer(t)
+	defer server.Close()
+	ai := NewAnthropic("test-token", "", true).(*Anthropic)
+	ai.url = server.URL
+	expectedInput := "Test input"
+
+	result, err := ai.IssueTitle(expectedInput, "")
+
+	require.NoError(t, err, "Expected no error when generating issue title")
+	assert.Contains(t, result, "Generate a one-line issue title", "Echo server should return a command")
+	assert.Contains(t, result, expectedInput, "Expected issue title to contain input")
+}
+
+func TestAnthropicAI_IssueBody(t *testing.T) {
+	server := anthropicEchoServer(t)
+	defer server.Close()
+	ai := NewAnthropic("test-token", "", true).(*Anthropic)
+	ai.url = server.URL
+	expectedInput := "Test input"
+
+	result, err := ai.IssueBody(expectedInput, "")
+
+	require.NoError(t, err, "Expected no error when generating issue body")
+	assert.Contains(t, result, "Generate an issue body", "Echo server should return a command")
+	assert.Contains(t, result, expectedInput, "Expected issue body to contain input")
+}
+
+func TestAnthropicAI_IssueLabels(t *testing.T) {
+	server := anthropicEchoServer(t)
+	defer server.Close()
+	ai := NewAnthropic("test-token", "", true).(*Anthropic)
+	ai.url = server.URL
+	expectedIssue := "Test issue"
+	availableLabels := []string{"bug", "feature", "enhancement"}
+
+	result, err := ai.IssueLabels(expectedIssue, availableLabels)
+
+	require.NoError(t, err, "Expected no error when generating issue labels")
+	for _, label := range availableLabels {
+		assert.Contains(t, result, label, "Expected issue labels to contain available labels")
+	}
+}
+
+func TestAnthropicAI_CommitMessage(t *testing.T) {
+	server := anthropicEchoServer(t)
+	defer server.Close()
+	ai := NewAnthropic("test-token", "", true).(*Anthropic)
+	ai.url = server.URL
+	expectedDiff := "Test diff"
+	expectedNumber := "42"
+
+	result, err := ai.CommitMessage(expectedNumber, expectedDiff, "")
+
+	require.NoError(t, err, "Expected no error when generating commit message")
+	assert.Contains(t, result, "generate a single-line commit message", "Echo server should return a command")
+	assert.Contains(t, result, expectedDiff, "Expected commit message to contain diff")
+}
+
+func TestAnthropicAI_SuggestBranch(t *testing.T) {
+	server := anthropicEchoServer(t)
+	defer server.Close()
+	ai := NewAnthropic("test-token", "", true).(*Anthropic)
+	ai.url = server.URL
+	expectedDescr := "Test description"
+
+	result, err := ai.SuggestBranch(expectedDescr)
+
+	require.NoError(t, err, "Expected no error when suggesting branch name")
+	assert.Contains(t, result, "Generate a branch name", "Echo server should return a command")
+	assert.Contains(t, result, expectedDescr, "Expected branch name to contain description")
+}
+
+func TestAnthropicAI_Handle404Response(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Not Found", http.StatusNotFound)
+	}))
+	defer server.Close()
+	ai := NewAnthropic("test-token", "", true).(*Anthropic)
+	ai.url = server.URL
+
+	_, err := ai.Summary("Test README content")
+
+	require.Error(t, err, "Expected an error when server returns 404")
+	assert.Contains(t, err.Error(), "API error: Not Found", "Expected error message to contain 'API error: Not Found'")
+}
+
+func TestAnthropicAI_DefaultModel(t *testing.T) {
+	ai := NewAnthropic("test-token", "", false).(*Anthropic)
+	assert.Equal(t, anthropicDefaultModel, ai.model, "Expected default model to be set")
+}
+
+func TestAnthropicAI_CustomModel(t *testing.T) {
+	ai := NewAnthropic("test-token", "claude-opus-4-7", false).(*Anthropic)
+	assert.Equal(t, "claude-opus-4-7", ai.model, "Expected custom model to be set")
+}
+
+func anthropicEchoServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err, "Failed to read request body")
+		var request anthropicRequest
+		err = json.Unmarshal(body, &request)
+		require.NoError(t, err, "Failed to unmarshal request body")
+		w.WriteHeader(http.StatusOK)
+		message := ""
+		if len(request.Messages) > 0 {
+			message = request.Messages[0].Content
+		}
+		message = replaceChars(message)
+		resp := fmt.Sprintf(`{"content":[{"type":"text","text":"%s"}]}`, message)
+		_, err = w.Write([]byte(resp))
+		require.NoError(t, err, "Failed to write response")
+	}))
+}
+
+func replaceChars(s string) string {
+	s = fmt.Sprintf("%s", s)
+	result := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '\n':
+			result = append(result, '\\', 'n')
+		case '"':
+			result = append(result, '\'')
+		default:
+			result = append(result, s[i])
+		}
+	}
+	return string(result)
+}

--- a/internal/aidy/real.go
+++ b/internal/aidy/real.go
@@ -696,6 +696,8 @@ func Brain(ailess bool, summary bool, conf config.Config) (ai.AI, error) {
 		brain = ai.NewDeepSeek(token, summary)
 	case "openai":
 		brain = ai.NewOpenAI(token, model, 0.2, summary)
+	case "anthropic":
+		brain = ai.NewAnthropic(token, model, summary)
 	default:
 		return nil, fmt.Errorf("unknown AI provider '%s' specified in configuration", provider)
 	}


### PR DESCRIPTION
Adds `anthropic` as a supported AI provider alongside `openai` and `deepseek`, enabling use of Claude models via the Anthropic API.

Fixes #279