### PR TITLE
feat(#278): add `--language` flag for multilingual AI text generation

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,23 +13,24 @@ func Execute() error {
 	return NewRootCmd(Real).Execute()
 }
 
-func Real(summary, aider, ailess, silent, debug bool) aidy.Aidy {
-	return aidy.NewAidy(summary, aider, ailess, silent, debug)
+func Real(summary, aider, ailess, silent, debug bool, language string) aidy.Aidy {
+	return aidy.NewAidy(summary, aider, ailess, silent, debug, language)
 }
 
-func NewRootCmd(create func(bool, bool, bool, bool, bool) aidy.Aidy) *cobra.Command {
+func NewRootCmd(create func(bool, bool, bool, bool, bool, string) aidy.Aidy) *cobra.Command {
 	var ctx Context
 	var ailess bool
 	var aider bool
 	var summary bool
 	var silent bool
 	var debug bool
+	var language string
 	root := &cobra.Command{
 		Use:   "aidy",
 		Short: "aidy - ai-powered github cli helper",
 		Long:  "Aidy assists you with generating commit messages, pull requests, issues, and releases",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			ctx.Assistant = create(summary, aider, ailess, silent, debug)
+			ctx.Assistant = create(summary, aider, ailess, silent, debug, language)
 		},
 	}
 	root.PersistentFlags().BoolVarP(&ailess, "no-ai", "n", false, "don't use AI")
@@ -37,6 +38,7 @@ func NewRootCmd(create func(bool, bool, bool, bool, bool) aidy.Aidy) *cobra.Comm
 	root.PersistentFlags().BoolVar(&aider, "aider", false, "use aider configuration")
 	root.PersistentFlags().BoolVarP(&silent, "quiet", "q", false, "be silent, don't print logs")
 	root.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "print debug logs")
+	root.PersistentFlags().StringVarP(&language, "language", "l", "en", "language for AI-generated text (e.g. fr, de, ja)")
 	root.AddCommand(
 		newCommitCmd(&ctx),
 		newIssueCmd(&ctx),

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -28,6 +28,6 @@ func TestRootCmd_Executes_WithoutError(t *testing.T) {
 	assert.NoError(t, err, "no error expected")
 }
 
-func mock(summary, aider, ailess, silent, debug bool) aidy.Aidy {
+func mock(summary, aider, ailess, silent, debug bool, language string) aidy.Aidy {
 	return aidy.NewMock()
 }

--- a/internal/ai/ai.go
+++ b/internal/ai/ai.go
@@ -38,3 +38,10 @@ func appendIssue(prompt, description string) string {
 	appendix := fmt.Sprintf("\nThis is the issue description for which you do it:\n<issue>\n%s\n</issue>\n", description)
 	return prompt + appendix
 }
+
+func appendLanguage(prompt, language string) string {
+	if language == "" || language == "en" {
+		return prompt
+	}
+	return fmt.Sprintf("You must respond entirely in %s language.\n\n", language) + prompt
+}

--- a/internal/ai/ai_test.go
+++ b/internal/ai/ai_test.go
@@ -136,6 +136,26 @@ func TestAppendIssue_WithEmptyPromptAndNonEmptyDescription_AppendsFormattedDescr
 	assert.Equal(t, expected, result)
 }
 
+func TestAppendLanguage_WhenLanguageIsEmpty_ReturnsPromptUnchanged(t *testing.T) {
+	result := appendLanguage("some prompt", "")
+	assert.Equal(t, "some prompt", result)
+}
+
+func TestAppendLanguage_WhenLanguageIsEnglish_ReturnsPromptUnchanged(t *testing.T) {
+	result := appendLanguage("some prompt", "en")
+	assert.Equal(t, "some prompt", result)
+}
+
+func TestAppendLanguage_WhenLanguageIsFrench_PrependsInstruction(t *testing.T) {
+	result := appendLanguage("some prompt", "fr")
+	assert.Equal(t, "You must respond entirely in fr language.\n\nsome prompt", result)
+}
+
+func TestAppendLanguage_WhenLanguageIsFullName_PrependsInstruction(t *testing.T) {
+	result := appendLanguage("some prompt", "German")
+	assert.Equal(t, "You must respond entirely in German language.\n\nsome prompt", result)
+}
+
 func TestAppendIssue_WhenPromptContainsSpecialCharacters_CombinesWithDescriptionProperly(t *testing.T) {
 	prompt := "Prompt with special chars: ~`|\\<>"
 	desc := "Description test"

--- a/internal/ai/anthropic.go
+++ b/internal/ai/anthropic.go
@@ -16,11 +16,12 @@ const anthropicDefaultModel = "claude-sonnet-4-6"
 const anthropicVersion = "2023-06-01"
 
 type Anthropic struct {
-	token   string
-	url     string
-	model   string
-	summary bool
-	log     log.Logger
+	token    string
+	url      string
+	model    string
+	summary  bool
+	language string
+	log      log.Logger
 }
 
 type anthropicRequest struct {
@@ -39,16 +40,17 @@ type anthropicResponse struct {
 	Content []anthropicContent `json:"content"`
 }
 
-func NewAnthropic(token, model string, summary bool) AI {
+func NewAnthropic(token, model string, summary bool, language string) AI {
 	if model == "" {
 		model = anthropicDefaultModel
 	}
 	return &Anthropic{
-		token:   token,
-		url:     "https://api.anthropic.com/v1/messages",
-		model:   model,
-		summary: summary,
-		log:     log.Default(),
+		token:    token,
+		url:      "https://api.anthropic.com/v1/messages",
+		model:    model,
+		summary:  summary,
+		language: language,
+		log:      log.Default(),
 	}
 }
 
@@ -114,6 +116,7 @@ func (a *Anthropic) send(system, user, summary string) (string, error) {
 	if a.summary {
 		content = appendSummary(content, summary)
 	}
+	content = appendLanguage(content, a.language)
 	content = trimPrompt(content)
 	body := anthropicRequest{
 		Model:     a.model,

--- a/internal/ai/anthropic_test.go
+++ b/internal/ai/anthropic_test.go
@@ -15,7 +15,7 @@ import (
 func TestAnthropicAI_Summary(t *testing.T) {
 	server := anthropicEchoServer(t)
 	defer server.Close()
-	ai := NewAnthropic("test-token", "", true).(*Anthropic)
+	ai := NewAnthropic("test-token", "", true, "en").(*Anthropic)
 	ai.url = server.URL
 	expected := "Test README content"
 
@@ -29,7 +29,7 @@ func TestAnthropicAI_Summary(t *testing.T) {
 func TestAnthropicAI_ReleaseNotes(t *testing.T) {
 	server := anthropicEchoServer(t)
 	defer server.Close()
-	ai := NewAnthropic("test-token", "", false).(*Anthropic)
+	ai := NewAnthropic("test-token", "", false, "en").(*Anthropic)
 	ai.url = server.URL
 	expected := "Test changes"
 
@@ -43,7 +43,7 @@ func TestAnthropicAI_ReleaseNotes(t *testing.T) {
 func TestAnthropicAI_PrTitle(t *testing.T) {
 	server := anthropicEchoServer(t)
 	defer server.Close()
-	ai := NewAnthropic("test-token", "", true).(*Anthropic)
+	ai := NewAnthropic("test-token", "", true, "en").(*Anthropic)
 	ai.url = server.URL
 	expectedDiff := "Test diff"
 	expectedIssue := "Test issue"
@@ -60,7 +60,7 @@ func TestAnthropicAI_PrTitle(t *testing.T) {
 func TestAnthropicAI_PrBody(t *testing.T) {
 	server := anthropicEchoServer(t)
 	defer server.Close()
-	ai := NewAnthropic("test-token", "", true).(*Anthropic)
+	ai := NewAnthropic("test-token", "", true, "en").(*Anthropic)
 	ai.url = server.URL
 	expectedDiff := "Test diff"
 	expectedIssue := "Test issue"
@@ -76,7 +76,7 @@ func TestAnthropicAI_PrBody(t *testing.T) {
 func TestAnthropicAI_IssueTitle(t *testing.T) {
 	server := anthropicEchoServer(t)
 	defer server.Close()
-	ai := NewAnthropic("test-token", "", true).(*Anthropic)
+	ai := NewAnthropic("test-token", "", true, "en").(*Anthropic)
 	ai.url = server.URL
 	expectedInput := "Test input"
 
@@ -90,7 +90,7 @@ func TestAnthropicAI_IssueTitle(t *testing.T) {
 func TestAnthropicAI_IssueBody(t *testing.T) {
 	server := anthropicEchoServer(t)
 	defer server.Close()
-	ai := NewAnthropic("test-token", "", true).(*Anthropic)
+	ai := NewAnthropic("test-token", "", true, "en").(*Anthropic)
 	ai.url = server.URL
 	expectedInput := "Test input"
 
@@ -104,7 +104,7 @@ func TestAnthropicAI_IssueBody(t *testing.T) {
 func TestAnthropicAI_IssueLabels(t *testing.T) {
 	server := anthropicEchoServer(t)
 	defer server.Close()
-	ai := NewAnthropic("test-token", "", true).(*Anthropic)
+	ai := NewAnthropic("test-token", "", true, "en").(*Anthropic)
 	ai.url = server.URL
 	expectedIssue := "Test issue"
 	availableLabels := []string{"bug", "feature", "enhancement"}
@@ -120,7 +120,7 @@ func TestAnthropicAI_IssueLabels(t *testing.T) {
 func TestAnthropicAI_CommitMessage(t *testing.T) {
 	server := anthropicEchoServer(t)
 	defer server.Close()
-	ai := NewAnthropic("test-token", "", true).(*Anthropic)
+	ai := NewAnthropic("test-token", "", true, "en").(*Anthropic)
 	ai.url = server.URL
 	expectedDiff := "Test diff"
 	expectedNumber := "42"
@@ -135,7 +135,7 @@ func TestAnthropicAI_CommitMessage(t *testing.T) {
 func TestAnthropicAI_SuggestBranch(t *testing.T) {
 	server := anthropicEchoServer(t)
 	defer server.Close()
-	ai := NewAnthropic("test-token", "", true).(*Anthropic)
+	ai := NewAnthropic("test-token", "", true, "en").(*Anthropic)
 	ai.url = server.URL
 	expectedDescr := "Test description"
 
@@ -151,7 +151,7 @@ func TestAnthropicAI_Handle404Response(t *testing.T) {
 		http.Error(w, "Not Found", http.StatusNotFound)
 	}))
 	defer server.Close()
-	ai := NewAnthropic("test-token", "", true).(*Anthropic)
+	ai := NewAnthropic("test-token", "", true, "en").(*Anthropic)
 	ai.url = server.URL
 
 	_, err := ai.Summary("Test README content")
@@ -161,12 +161,12 @@ func TestAnthropicAI_Handle404Response(t *testing.T) {
 }
 
 func TestAnthropicAI_DefaultModel(t *testing.T) {
-	ai := NewAnthropic("test-token", "", false).(*Anthropic)
+	ai := NewAnthropic("test-token", "", false, "en").(*Anthropic)
 	assert.Equal(t, anthropicDefaultModel, ai.model, "Expected default model to be set")
 }
 
 func TestAnthropicAI_CustomModel(t *testing.T) {
-	ai := NewAnthropic("test-token", "claude-opus-4-7", false).(*Anthropic)
+	ai := NewAnthropic("test-token", "claude-opus-4-7", false, "en").(*Anthropic)
 	assert.Equal(t, "claude-opus-4-7", ai.model, "Expected custom model to be set")
 }
 

--- a/internal/ai/deepseek.go
+++ b/internal/ai/deepseek.go
@@ -13,11 +13,12 @@ import (
 )
 
 type DeepSeek struct {
-	token   string
-	url     string
-	model   string
-	summary bool
-	log     log.Logger
+	token    string
+	url      string
+	model    string
+	summary  bool
+	language string
+	log      log.Logger
 }
 
 type chatMessage struct {
@@ -39,13 +40,14 @@ type chatResponse struct {
 	Choices []chatChoice `json:"choices"`
 }
 
-func NewDeepSeek(apiKey string, summary bool) AI {
+func NewDeepSeek(apiKey string, summary bool, language string) AI {
 	return &DeepSeek{
-		token:   apiKey,
-		url:     "https://api.deepseek.com/chat/completions",
-		model:   "deepseek-chat",
-		summary: summary,
-		log:     log.Default(),
+		token:    apiKey,
+		url:      "https://api.deepseek.com/chat/completions",
+		model:    "deepseek-chat",
+		summary:  summary,
+		language: language,
+		log:      log.Default(),
 	}
 }
 
@@ -111,6 +113,7 @@ func (d *DeepSeek) send(system string, user string, summary string) (string, err
 	if d.summary {
 		content = appendSummary(content, summary)
 	}
+	content = appendLanguage(content, d.language)
 	content = trimPrompt(content)
 	body := chatRequest{
 		Model: d.model,

--- a/internal/ai/deepseek_test.go
+++ b/internal/ai/deepseek_test.go
@@ -16,7 +16,7 @@ import (
 func TestDeepSeekAI_Summary(t *testing.T) {
 	server := echoServer(t)
 	defer server.Close()
-	ai := NewDeepSeek("test-token", true).(*DeepSeek)
+	ai := NewDeepSeek("test-token", true, "en").(*DeepSeek)
 	ai.url = server.URL
 	expected := "Test README content"
 
@@ -30,7 +30,7 @@ func TestDeepSeekAI_Summary(t *testing.T) {
 func TestDeepSeekAI_ReleaseNotes(t *testing.T) {
 	server := echoServer(t)
 	defer server.Close()
-	ai := NewDeepSeek("test-token", false).(*DeepSeek)
+	ai := NewDeepSeek("test-token", false, "en").(*DeepSeek)
 	ai.url = server.URL
 	expected := "Test changes"
 
@@ -44,7 +44,7 @@ func TestDeepSeekAI_ReleaseNotes(t *testing.T) {
 func TestDeepSeekAI_PrTitle(t *testing.T) {
 	server := echoServer(t)
 	defer server.Close()
-	ai := NewDeepSeek("test-token", true).(*DeepSeek)
+	ai := NewDeepSeek("test-token", true, "en").(*DeepSeek)
 	ai.url = server.URL
 	expectedDiff := "Test diff"
 	expectedIssue := "Test issue"
@@ -61,7 +61,7 @@ func TestDeepSeekAI_PrTitle(t *testing.T) {
 func TestDeepSeekAI_PrBody(t *testing.T) {
 	server := echoServer(t)
 	defer server.Close()
-	ai := NewDeepSeek("test-token", true).(*DeepSeek)
+	ai := NewDeepSeek("test-token", true, "en").(*DeepSeek)
 	ai.url = server.URL
 	expectedDiff := "Test diff"
 	expectedIssue := "Test issue"
@@ -77,7 +77,7 @@ func TestDeepSeekAI_PrBody(t *testing.T) {
 func TestDeepSeekAI_IssueTitle(t *testing.T) {
 	server := echoServer(t)
 	defer server.Close()
-	ai := NewDeepSeek("test-token", true).(*DeepSeek)
+	ai := NewDeepSeek("test-token", true, "en").(*DeepSeek)
 	ai.url = server.URL
 	expectedInput := "Test input"
 
@@ -91,7 +91,7 @@ func TestDeepSeekAI_IssueTitle(t *testing.T) {
 func TestDeepSeekAI_IssueBody(t *testing.T) {
 	server := echoServer(t)
 	defer server.Close()
-	ai := NewDeepSeek("test-token", true).(*DeepSeek)
+	ai := NewDeepSeek("test-token", true, "en").(*DeepSeek)
 	ai.url = server.URL
 	expectedInput := "Test input"
 
@@ -105,7 +105,7 @@ func TestDeepSeekAI_IssueBody(t *testing.T) {
 func TestDeepSeekAI_IssueLabels(t *testing.T) {
 	server := echoServer(t)
 	defer server.Close()
-	ai := NewDeepSeek("test-token", true).(*DeepSeek)
+	ai := NewDeepSeek("test-token", true, "en").(*DeepSeek)
 	ai.url = server.URL
 	expectedIssue := "Test issue"
 	availableLabels := []string{"bug", "feature", "enhancement"}
@@ -121,7 +121,7 @@ func TestDeepSeekAI_IssueLabels(t *testing.T) {
 func TestDeepSeekAI_CommitMessage(t *testing.T) {
 	server := echoServer(t)
 	defer server.Close()
-	ai := NewDeepSeek("test-token", true).(*DeepSeek)
+	ai := NewDeepSeek("test-token", true, "en").(*DeepSeek)
 	ai.url = server.URL
 	expectedDiff := "Test diff"
 	expectedNumber := "42"
@@ -136,7 +136,7 @@ func TestDeepSeekAI_CommitMessage(t *testing.T) {
 func TestDeepSeekAI_SuggestBranch(t *testing.T) {
 	server := echoServer(t)
 	defer server.Close()
-	ai := NewDeepSeek("test-token", true).(*DeepSeek)
+	ai := NewDeepSeek("test-token", true, "en").(*DeepSeek)
 	ai.url = server.URL
 	expectedDescr := "Test description"
 
@@ -152,7 +152,7 @@ func TestDeepSeekAI_Handle404Response(t *testing.T) {
 		http.Error(w, "Not Found", http.StatusNotFound)
 	}))
 	defer server.Close()
-	ai := NewDeepSeek("test-token", true).(*DeepSeek)
+	ai := NewDeepSeek("test-token", true, "en").(*DeepSeek)
 	ai.url = server.URL
 
 	_, err := ai.Summary("Test README content")

--- a/internal/ai/openai.go
+++ b/internal/ai/openai.go
@@ -17,18 +17,20 @@ type OpenAI struct {
 	model       string
 	temperature float32
 	summary     bool
+	language    string
 }
 
-func NewOpenAI(token, model string, temperature float32, summary bool) *OpenAI {
-	return NewOpenAIWithClient(openai.NewClient(token), model, temperature, summary)
+func NewOpenAI(token, model string, temperature float32, summary bool, language string) *OpenAI {
+	return NewOpenAIWithClient(openai.NewClient(token), model, temperature, summary, language)
 }
 
-func NewOpenAIWithClient(client openClient, model string, temperature float32, summary bool) *OpenAI {
+func NewOpenAIWithClient(client openClient, model string, temperature float32, summary bool, language string) *OpenAI {
 	return &OpenAI{
 		client:      client,
 		model:       model,
 		temperature: temperature,
 		summary:     summary,
+		language:    language,
 	}
 }
 
@@ -97,6 +99,7 @@ func (o *OpenAI) send(prompt, summary string) (string, error) {
 	if o.summary {
 		content = appendSummary(content, summary)
 	}
+	content = appendLanguage(content, o.language)
 	content = trimPrompt(content)
 	req := openai.ChatCompletionRequest{
 		Model: o.model,

--- a/internal/ai/openai_test.go
+++ b/internal/ai/openai_test.go
@@ -37,7 +37,7 @@ func (m echo) CreateChatCompletion(ctx context.Context, req openai.ChatCompletio
 }
 
 func TestOpenAi_GeneratesTitle(t *testing.T) {
-	openAI := NewOpenAIWithClient(NewEcho(), "test-model", 0.5, false)
+	openAI := NewOpenAIWithClient(NewEcho(), "test-model", 0.5, false, "en")
 
 	title, err := openAI.PrTitle("123", "test diff", "successful issue-description", "project-summary")
 
@@ -46,7 +46,7 @@ func TestOpenAi_GeneratesTitle(t *testing.T) {
 }
 
 func TestOpenAi_GeneratesTitleWithError(t *testing.T) {
-	openAI := NewOpenAIWithClient(NewEcho(), "test-model", 0.5, false)
+	openAI := NewOpenAIWithClient(NewEcho(), "test-model", 0.5, false, "en")
 
 	_, err := openAI.PrTitle("123", "test diff", "error issue-description", "project-summary")
 
@@ -55,7 +55,7 @@ func TestOpenAi_GeneratesTitleWithError(t *testing.T) {
 }
 
 func TestOpenAi_GeneratesBody(t *testing.T) {
-	openai := NewOpenAIWithClient(NewEcho(), "test-model", 0.5, false)
+	openai := NewOpenAIWithClient(NewEcho(), "test-model", 0.5, false, "en")
 
 	body, err := openai.PrBody("test diff", "successful issue-description", "project-summary")
 
@@ -64,7 +64,7 @@ func TestOpenAi_GeneratesBody(t *testing.T) {
 }
 
 func TestOpenAI_SuggestBranch(t *testing.T) {
-	openAI := NewOpenAIWithClient(NewEcho(), "test-model", 0.5, false)
+	openAI := NewOpenAIWithClient(NewEcho(), "test-model", 0.5, false, "en")
 	description := "successful description"
 
 	branch, err := openAI.SuggestBranch(description)
@@ -75,7 +75,7 @@ func TestOpenAI_SuggestBranch(t *testing.T) {
 }
 
 func TestOpenAI_SuggestBranch_Error(t *testing.T) {
-	openAI := NewOpenAIWithClient(NewEcho(), "test-model", 0.5, false)
+	openAI := NewOpenAIWithClient(NewEcho(), "test-model", 0.5, false, "en")
 	description := "error description"
 
 	_, err := openAI.SuggestBranch(description)
@@ -85,7 +85,7 @@ func TestOpenAI_SuggestBranch_Error(t *testing.T) {
 }
 
 func TestOpenAI_ReleaseNotes(t *testing.T) {
-	openAI := NewOpenAIWithClient(NewEcho(), "test-model", 0.5, false)
+	openAI := NewOpenAIWithClient(NewEcho(), "test-model", 0.5, false, "en")
 	changes := "successful changes"
 
 	notes, err := openAI.ReleaseNotes(changes)
@@ -96,7 +96,7 @@ func TestOpenAI_ReleaseNotes(t *testing.T) {
 }
 
 func TestOpenAI_ReleaseNotes_Error(t *testing.T) {
-	openAI := NewOpenAIWithClient(NewEcho(), "test-model", 0.5, false)
+	openAI := NewOpenAIWithClient(NewEcho(), "test-model", 0.5, false, "en")
 	changes := "error changes"
 
 	_, err := openAI.ReleaseNotes(changes)
@@ -106,7 +106,7 @@ func TestOpenAI_ReleaseNotes_Error(t *testing.T) {
 }
 
 func TestOpenAI_IssueTitle(t *testing.T) {
-	openAI := NewOpenAIWithClient(NewEcho(), "test-model", 0.5, false)
+	openAI := NewOpenAIWithClient(NewEcho(), "test-model", 0.5, false, "en")
 	input := "successful issue input"
 
 	title, err := openAI.IssueTitle(input, "project-summary")
@@ -117,7 +117,7 @@ func TestOpenAI_IssueTitle(t *testing.T) {
 }
 
 func TestOpenAI_IssueBody(t *testing.T) {
-	openAI := NewOpenAIWithClient(NewEcho(), "test-model", 0.5, false)
+	openAI := NewOpenAIWithClient(NewEcho(), "test-model", 0.5, false, "en")
 	input := "successful issue input"
 
 	body, err := openAI.IssueBody(input, "project-summary")
@@ -128,7 +128,7 @@ func TestOpenAI_IssueBody(t *testing.T) {
 }
 
 func TestOpenAI_CommitMessage(t *testing.T) {
-	openAI := NewOpenAIWithClient(NewEcho(), "test-model", 0.5, false)
+	openAI := NewOpenAIWithClient(NewEcho(), "test-model", 0.5, false, "en")
 	number := "123"
 	diff := "successful diff"
 
@@ -140,7 +140,7 @@ func TestOpenAI_CommitMessage(t *testing.T) {
 }
 
 func TestOpenAI_IssueLabels(t *testing.T) {
-	openAI := NewOpenAIWithClient(NewEcho(), "test-model", 0.5, false)
+	openAI := NewOpenAIWithClient(NewEcho(), "test-model", 0.5, false, "en")
 	issue := "I successfully suggest using 'feature' label here"
 	available := []string{"bug", "feature", "enhancement"}
 

--- a/internal/aidy/real.go
+++ b/internal/aidy/real.go
@@ -41,7 +41,8 @@ type real struct {
 // - ailess: whether to use AI or not
 // - silent: whether to suppress output
 // - debug: whether to enable debug logging
-func NewAidy(summary bool, aider bool, ailess bool, silent bool, debug bool) Aidy {
+// - language: language for AI-generated text (e.g. "en", "fr", "de"); defaults to "en"
+func NewAidy(summary bool, aider bool, ailess bool, silent bool, debug bool, language string) Aidy {
 	var aidy real
 	aidy.in = os.Stdin
 	InitLogger(silent, debug)
@@ -66,7 +67,7 @@ func NewAidy(summary bool, aider bool, ailess bool, silent bool, debug bool) Aid
 		aidy.logger.Error("failed to initialize configuration: %v", err)
 		os.Exit(1)
 	}
-	if aidy.ai, err = Brain(ailess, summary, aidy.config); err != nil {
+	if aidy.ai, err = Brain(ailess, summary, aidy.config, language); err != nil {
 		aidy.logger.Error("failed to initialize AI: %v", err)
 		os.Exit(1)
 	}
@@ -671,7 +672,7 @@ func NewConf(aider bool, git git.Git) (config.Config, error) {
 	return conf, nil
 }
 
-func Brain(ailess bool, summary bool, conf config.Config) (ai.AI, error) {
+func Brain(ailess bool, summary bool, conf config.Config, language string) (ai.AI, error) {
 	if ailess {
 		return ai.NewMockAI(), nil
 	}
@@ -693,11 +694,11 @@ func Brain(ailess bool, summary bool, conf config.Config) (ai.AI, error) {
 	var brain ai.AI
 	switch provider {
 	case "deepseek":
-		brain = ai.NewDeepSeek(token, summary)
+		brain = ai.NewDeepSeek(token, summary, language)
 	case "openai":
-		brain = ai.NewOpenAI(token, model, 0.2, summary)
+		brain = ai.NewOpenAI(token, model, 0.2, summary, language)
 	case "anthropic":
-		brain = ai.NewAnthropic(token, model, summary)
+		brain = ai.NewAnthropic(token, model, summary, language)
 	default:
 		return nil, fmt.Errorf("unknown AI provider '%s' specified in configuration", provider)
 	}

--- a/internal/aidy/real_test.go
+++ b/internal/aidy/real_test.go
@@ -72,7 +72,7 @@ func TestReal_NewCache_CreatesSuccessfully(t *testing.T) {
 }
 
 func TestReal_InitialisesAI_Mock(t *testing.T) {
-	brain, err := Brain(true, false, config.NewMock())
+	brain, err := Brain(true, false, config.NewMock(), "en")
 
 	require.NoError(t, err, "Expected no error when initializing AI")
 	assert.NotNil(t, brain, "Expected brain to be initialized")
@@ -81,7 +81,7 @@ func TestReal_InitialisesAI_Mock(t *testing.T) {
 func TestReal_InitialisesAI_OpenAI(t *testing.T) {
 	conf := config.NewMock()
 	conf.MockProvider = "openai"
-	brain, err := Brain(false, false, conf)
+	brain, err := Brain(false, false, conf, "en")
 
 	require.NoError(t, err, "Expected no error when initializing AI without cache")
 	assert.NotNil(t, brain, "Expected brain to be initialized")
@@ -91,7 +91,7 @@ func TestReal_InitialisesAI_DeepSeek(t *testing.T) {
 	conf := config.NewMock()
 	conf.MockProvider = "deepseek"
 
-	brain, err := Brain(false, false, conf)
+	brain, err := Brain(false, false, conf, "en")
 
 	require.NoError(t, err, "Expected no error when initializing AI without cache")
 	assert.NotNil(t, brain, "Expected brain to be initialized")
@@ -101,7 +101,7 @@ func TestReal_InitialisesAI_UnknownProvider(t *testing.T) {
 	conf := config.NewMock()
 	conf.MockProvider = "unknown"
 
-	brain, err := Brain(false, false, conf)
+	brain, err := Brain(false, false, conf, "en")
 
 	require.Error(t, err, "Expected error when initializing AI with unknown provider")
 	assert.Nil(t, brain, "Expected brain to be nil when provider is unknown")
@@ -111,7 +111,7 @@ func TestReal_InitSummary_ErrorGettingProvider(t *testing.T) {
 	conf := config.NewMock()
 	conf.Error = fmt.Errorf("error getting provider")
 
-	brain, err := Brain(false, false, conf)
+	brain, err := Brain(false, false, conf, "en")
 
 	require.Error(t, err, "Expected error when getting provider fails")
 	assert.Nil(t, brain, "Expected brain to be nil when getting provider fails")


### PR DESCRIPTION
Adds a `--language` / `-l` flag (default `en`) to allow AI-generated text to be produced in any language, propagating the setting through all AI backends.

Fixes #278