### PR TITLE
feat(#277): add `mr` command for GitLab merge request support

### DIFF
--- a/cmd/mr.go
+++ b/cmd/mr.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func newMrCmd(ctx *Context) *cobra.Command {
+	fixes := false
+	command := &cobra.Command{
+		Use:     "merge-request",
+		Aliases: []string{"mr"},
+		Short:   "Create a MR based on changes in the current branch",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return ctx.Assistant.MergeRequest(fixes)
+		},
+	}
+	command.Flags().BoolVarP(&fixes, "fixes", "f", false, "Create a MR with 'fixes' keyword")
+	return command
+}

--- a/cmd/mr_test.go
+++ b/cmd/mr_test.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/volodya-lombrozo/aidy/internal/aidy"
+)
+
+func TestMr_Help(t *testing.T) {
+	var out bytes.Buffer
+	command := newMrCmd(&Context{})
+	command.SetOut(&out)
+	command.SetArgs([]string{"--help"})
+
+	err := command.Execute()
+
+	require.NoError(t, err, "no error expected")
+	assert.Contains(t, out.String(), "Create a MR based on changes in the current branch")
+}
+
+func TestMr_Execution(t *testing.T) {
+	mock := aidy.NewMock()
+	ctx := &Context{Assistant: mock}
+	command := newMrCmd(ctx)
+
+	err := command.Execute()
+
+	require.NoError(t, err, "no error expected")
+	assert.Contains(t, mock.Logs(), "MergeRequest called")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -44,6 +44,7 @@ func NewRootCmd(create func(bool, bool, bool, bool, bool, string) aidy.Aidy) *co
 		newIssueCmd(&ctx),
 		newReleaseCmd(&ctx),
 		newPrCmd(&ctx),
+		newMrCmd(&ctx),
 		newHealCmd(&ctx),
 		newSquashCmd(&ctx),
 		newAppendCmd(&ctx),

--- a/internal/aidy/aidy.go
+++ b/internal/aidy/aidy.go
@@ -6,6 +6,7 @@ type Aidy interface {
 	Commit(issue bool) error
 	Squash(issue bool)
 	PullRequest(fixes bool) error
+	MergeRequest(fixes bool) error
 	Issue(task string) error
 	Heal() error
 	Append()

--- a/internal/aidy/mock.go
+++ b/internal/aidy/mock.go
@@ -34,6 +34,11 @@ func (m *Mock) PullRequest(fixes bool) error {
 	return nil
 }
 
+func (m *Mock) MergeRequest(fixes bool) error {
+	m.logs = append(m.logs, "MergeRequest called")
+	return nil
+}
+
 func (m *Mock) Issue(task string) error {
 	m.logs = append(m.logs, fmt.Sprintf("Issue called with task: %s", task))
 	return nil

--- a/internal/aidy/real.go
+++ b/internal/aidy/real.go
@@ -22,8 +22,8 @@ import (
 )
 
 type real struct {
-	git     git.Git
-	github  github.Github
+	git    git.Git
+	github github.Github
 	ai      ai.AI
 	editor  output.Output
 	config  config.Config
@@ -376,6 +376,38 @@ func (r *real) PullRequest(fixes bool) error {
 	prtitle := healPRTitle(healQuotes(title), nissue)
 	prbody := healQuotes(body)
 	cmd := escapeBackticks(fmt.Sprintf("gh pr create --title \"%s\" --body \"%s\"%s", prtitle, prbody, repo))
+	return r.editor.Print(cmd)
+}
+
+func (r *real) MergeRequest(fixes bool) error {
+	branch, err := r.git.CurrentBranch()
+	if err != nil {
+		return fmt.Errorf("error getting branch name: %v", err)
+	}
+	diff, err := r.git.Diff()
+	if err != nil {
+		return fmt.Errorf("error getting git diff: %v", err)
+	}
+	summary, _ := r.cache.Summary()
+	nissue := inumber(branch)
+	r.logger.Info("generating merge request title...")
+	title, err := r.ai.PrTitle(issueRef(nissue), diff, "", summary)
+	if err != nil {
+		return fmt.Errorf("error generating merge request title: %v", err)
+	}
+	r.logger.Info("generating merge request body...")
+	body, err := r.ai.PrBody(diff, "", summary)
+	if err != nil {
+		return fmt.Errorf("error generating merge request body: %v", err)
+	}
+	if fixes {
+		body = body + fmt.Sprintf("\n\nCloses %s", issueRef(nissue))
+	} else {
+		body = body + fmt.Sprintf("\n\nRelated to %s", issueRef(nissue))
+	}
+	mrtitle := healPRTitle(healQuotes(title), nissue)
+	mrbody := healQuotes(body)
+	cmd := escapeBackticks(fmt.Sprintf("glab mr create --title \"%s\" --body \"%s\"", mrtitle, mrbody))
 	return r.editor.Print(cmd)
 }
 

--- a/internal/aidy/real_test.go
+++ b/internal/aidy/real_test.go
@@ -598,6 +598,30 @@ func TestReal_PullRequest_Fixes(t *testing.T) {
 	assert.Contains(t, output, "Fixes #")
 }
 
+func TestReal_MergeRequest(t *testing.T) {
+	out := output.NewMock()
+	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github.NewMock(), editor: out, cache: cache.NewMockAidyCache(), logger: log.Default()}
+
+	err := raidy.MergeRequest(false)
+
+	require.NoError(t, err, "expected no error when creating merge request")
+	result := out.Last()
+	assert.Contains(t, result, "glab mr create", "Expected output to contain 'glab mr create'")
+	assert.Contains(t, result, "Related to #")
+}
+
+func TestReal_MergeRequest_Fixes(t *testing.T) {
+	out := output.NewMock()
+	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github.NewMock(), editor: out, cache: cache.NewMockAidyCache(), logger: log.NewMock()}
+
+	err := raidy.MergeRequest(true)
+
+	require.NoError(t, err, "expected no error when creating merge request with fixes")
+	result := out.Last()
+	assert.Contains(t, result, "glab mr create")
+	assert.Contains(t, result, "Closes #")
+}
+
 func TestReal_Commit(t *testing.T) {
 	brain := ai.NewMockAI()
 	shell := executor.NewMock()


### PR DESCRIPTION
Adds a `mr` command to create GitLab merge requests via `glab`, mirroring the existing `pr` command for GitHub pull requests.

Fixes #277