### PR TITLE
fix(#284): strip backticks from generated branch names

### DIFF
--- a/internal/aidy/real.go
+++ b/internal/aidy/real.go
@@ -498,6 +498,7 @@ func branchName(number string, suggested string) string {
 	suggested = strings.ReplaceAll(suggested, " ", "-")
 	suggested = strings.ReplaceAll(suggested, "_", "-")
 	suggested = strings.ReplaceAll(suggested, "/", "-")
+	suggested = strings.ReplaceAll(suggested, "`", "")
 	return fmt.Sprintf("%s-%s", number, suggested)
 }
 

--- a/internal/aidy/real_test.go
+++ b/internal/aidy/real_test.go
@@ -856,6 +856,11 @@ func TestExtractIssueNumber(t *testing.T) {
 	}
 }
 
+func TestBranchName(t *testing.T) {
+	assert.Equal(t, "283-fix-mr-body-flag", branchName("283", "`fix-mr-body-flag`"))
+	assert.Equal(t, "42-fix-bug", branchName("42", "fix-bug"))
+}
+
 func TestEscapeBackticks(t *testing.T) {
 	input := "This is a `test` string with `backticks`."
 	expected := "This is a \\`test\\` string with \\`backticks\\`."


### PR DESCRIPTION
Strip backticks from generated branch names to prevent invalid branch names when issue titles contain backtick-wrapped identifiers.

Fixes #284