### PR TITLE
feat(#286): add `version` command to print current aidy version

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,6 +7,8 @@ before:
 builds:
   - env:
       - CGO_ENABLED=0
+    ldflags:
+      - -s -w -X github.com/volodya-lombrozo/aidy/cmd.Version={{.Version}}
     goos:
       - linux
       - windows

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,9 +26,10 @@ func NewRootCmd(create func(bool, bool, bool, bool, bool, string) aidy.Aidy) *co
 	var debug bool
 	var language string
 	root := &cobra.Command{
-		Use:   "aidy",
-		Short: "aidy - ai-powered github cli helper",
-		Long:  "Aidy assists you with generating commit messages, pull requests, issues, and releases",
+		Use:     "aidy",
+		Short:   "aidy - ai-powered github cli helper",
+		Long:    "Aidy assists you with generating commit messages, pull requests, issues, and releases",
+		Version: Version,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			ctx.Assistant = create(summary, aider, ailess, silent, debug, language)
 		},
@@ -52,6 +53,7 @@ func NewRootCmd(create func(bool, bool, bool, bool, bool, string) aidy.Aidy) *co
 		newCleanCmd(&ctx),
 		newStartCmd(&ctx),
 		newDiffCmd(&ctx),
+		newVersionCmd(),
 	)
 	return root
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var Version = "dev"
+
+func newVersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print the current aidy version",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, err := fmt.Fprintln(cmd.OutOrStdout(), Version)
+			return err
+		},
+	}
+}

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionCmd_PrintsVersion(t *testing.T) {
+	var out bytes.Buffer
+	command := newVersionCmd()
+	command.SetOut(&out)
+
+	err := command.Execute()
+
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "dev")
+}
+
+func TestVersionCmd_Help(t *testing.T) {
+	var out bytes.Buffer
+	command := newVersionCmd()
+	command.SetOut(&out)
+	command.SetArgs([]string{"--help"})
+
+	err := command.Execute()
+
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "Print the current aidy version")
+}


### PR DESCRIPTION
Adds a `version` subcommand and `--version` flag so users can check which version of `aidy` is installed. The version is injected at build time via `ldflags`.

Fixes #286