### PR TITLE
fix(#292): return to confirmation prompt after editing command

### DIFF
--- a/internal/output/editor.go
+++ b/internal/output/editor.go
@@ -34,9 +34,9 @@ func NewEditor(shell executor.Executor) *editor {
 func (e *editor) Print(command string) error {
 	cmd := prettyCommand(command)
 	fmt.Printf("\ngenerated command:\n%s\n", cmd)
+	reader := bufio.NewReader(e.in)
 	for {
 		e.printf("%s", "[r]un, [e]dit, [c]ancel, [p]rint? ")
-		reader := bufio.NewReader(e.in)
 		line, err := reader.ReadString('\n')
 		if err != nil {
 			e.printfErr("%s: %v\n", "Error reading input", err)
@@ -55,7 +55,6 @@ func (e *editor) Print(command string) error {
 				return nil
 			}
 			cmd = updated
-			return e.run(cmd)
 		case "c":
 			e.printf("%s\n", "canceled.")
 			return nil

--- a/internal/output/editor.go
+++ b/internal/output/editor.go
@@ -55,6 +55,7 @@ func (e *editor) Print(command string) error {
 				return nil
 			}
 			cmd = updated
+			e.printf("\nupdated command:\n%s\n", cmd)
 		case "c":
 			e.printf("%s\n", "canceled.")
 			return nil

--- a/internal/output/editor_test.go
+++ b/internal/output/editor_test.go
@@ -99,7 +99,7 @@ func TestEditor_Print_EditOption(t *testing.T) {
 	shell := executor.NewMock()
 	editor := NewEditor(shell)
 	editor.in = r
-	_, err := io.WriteString(w, "e\n")
+	_, err := io.WriteString(w, "e\nr\n")
 	require.NoError(t, err, "failed to write to pipe")
 	err = w.Close()
 	require.NoError(t, err, "failed to close write pipe")

--- a/internal/output/editor_test.go
+++ b/internal/output/editor_test.go
@@ -95,20 +95,28 @@ func TestEditor_Print_CancelOption(t *testing.T) {
 }
 
 func TestEditor_Print_EditOption(t *testing.T) {
-	r, w, _ := os.Pipe()
+	input_r, input_w, _ := os.Pipe()
+	output_r, output_w, _ := os.Pipe()
 	shell := executor.NewMock()
 	editor := NewEditor(shell)
-	editor.in = r
-	_, err := io.WriteString(w, "e\nr\n")
+	editor.in = input_r
+	editor.out = output_w
+	_, err := io.WriteString(input_w, "e\nr\n")
 	require.NoError(t, err, "failed to write to pipe")
-	err = w.Close()
+	err = input_w.Close()
 	require.NoError(t, err, "failed to close write pipe")
 	command := "echo 'Hello, World!'"
 
 	_ = editor.Print(command)
 
+	err = output_w.Close()
+	require.NoError(t, err, "failed to close output pipe")
+	output, err := io.ReadAll(output_r)
+	require.NoError(t, err, "failed to read from output")
 	assert.Len(t, shell.Commands, 2, "expected 2 commands to be run")
 	assert.Equal(t, command, shell.Commands[1], "expected edited command to match")
+	assert.Contains(t, string(output), "updated command", "expected updated command label in output")
+	assert.Contains(t, string(output), command, "expected updated command content in output")
 }
 
 func TestEditor_Print_EditOption_FailsWithError(t *testing.T) {


### PR DESCRIPTION
After editing a command, return to the confirmation prompt instead of running immediately, and display the updated command for review.

Fixes #292