### PR TITLE
fix(#291): silence usage output on runtime errors

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,6 +31,7 @@ func NewRootCmd(create func(bool, bool, bool, bool, bool, string) aidy.Aidy) *co
 		Long:    "Aidy assists you with generating commit messages, pull requests, issues, and releases",
 		Version: Version,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			cmd.Root().SilenceUsage = true
 			ctx.Assistant = create(summary, aider, ailess, silent, debug, language)
 		},
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -28,6 +28,31 @@ func TestRootCmd_Executes_WithoutError(t *testing.T) {
 	assert.NoError(t, err, "no error expected")
 }
 
+func TestRootCmd_PrintsUsageOnBadInput(t *testing.T) {
+	var out bytes.Buffer
+	command := NewRootCmd(mock)
+	command.SetOut(&out)
+	command.SetArgs([]string{"commit", "--unknown-flag"})
+
+	_ = command.Execute()
+
+	assert.Contains(t, out.String(), "Usage:", "usage should be printed on bad user input")
+}
+
+func TestRootCmd_SilencesUsageOnRuntimeError(t *testing.T) {
+	failing := func(summary, aider, ailess, silent, debug bool, language string) aidy.Aidy {
+		return aidy.NewFailingMock()
+	}
+	var out bytes.Buffer
+	command := NewRootCmd(failing)
+	command.SetOut(&out)
+	command.SetArgs([]string{"commit"})
+
+	_ = command.Execute()
+
+	assert.NotContains(t, out.String(), "Usage:", "usage should not be printed on runtime errors")
+}
+
 func mock(summary, aider, ailess, silent, debug bool, language string) aidy.Aidy {
 	return aidy.NewMock()
 }

--- a/internal/aidy/mock.go
+++ b/internal/aidy/mock.go
@@ -1,6 +1,9 @@
 package aidy
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 type Mock struct {
 	logs []string
@@ -70,3 +73,22 @@ func (m *Mock) StartIssue(number string) error {
 func (m *Mock) Logs() []string {
 	return m.logs
 }
+
+type FailingMock struct{}
+
+func NewFailingMock() *FailingMock {
+	return &FailingMock{}
+}
+
+func (f *FailingMock) Release(interval string, repo string) error   { return errors.New("error") }
+func (f *FailingMock) PrintConfig() error                           { return errors.New("error") }
+func (f *FailingMock) Commit(issue bool) error                      { return errors.New("error") }
+func (f *FailingMock) Squash(issue bool)                            {}
+func (f *FailingMock) PullRequest(fixes bool) error                 { return errors.New("error") }
+func (f *FailingMock) MergeRequest(fixes bool) error                { return errors.New("error") }
+func (f *FailingMock) Issue(task string) error                      { return errors.New("error") }
+func (f *FailingMock) Heal() error                                   { return errors.New("error") }
+func (f *FailingMock) Append()                                       {}
+func (f *FailingMock) Clean()                                        {}
+func (f *FailingMock) Diff() error                                   { return errors.New("error") }
+func (f *FailingMock) StartIssue(number string) error               { return errors.New("error") }


### PR DESCRIPTION
Suppress usage output on runtime errors by setting `SilenceUsage` once a command begins executing, while preserving usage display on invalid user input.

Fixes #291