### PR TITLE
feat(#296): add `--target`/`-t` flag to `pr` and `mr` commands

### DIFF
--- a/cmd/mr.go
+++ b/cmd/mr.go
@@ -6,14 +6,16 @@ import (
 
 func newMrCmd(ctx *Context) *cobra.Command {
 	fixes := false
+	target := ""
 	command := &cobra.Command{
 		Use:     "merge-request",
 		Aliases: []string{"mr"},
 		Short:   "Create a MR based on changes in the current branch",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return ctx.Assistant.MergeRequest(fixes)
+			return ctx.Assistant.MergeRequest(fixes, target)
 		},
 	}
 	command.Flags().BoolVarP(&fixes, "fixes", "f", false, "Create a MR with 'fixes' keyword")
+	command.Flags().StringVarP(&target, "target", "t", "", "Target branch for the MR")
 	return command
 }

--- a/cmd/mr_test.go
+++ b/cmd/mr_test.go
@@ -31,3 +31,15 @@ func TestMr_Execution(t *testing.T) {
 	require.NoError(t, err, "no error expected")
 	assert.Contains(t, mock.Logs(), "MergeRequest called")
 }
+
+func TestMr_ExecutionWithTarget(t *testing.T) {
+	mock := aidy.NewMock()
+	ctx := &Context{Assistant: mock}
+	command := newMrCmd(ctx)
+	command.SetArgs([]string{"--target", "develop"})
+
+	err := command.Execute()
+
+	require.NoError(t, err, "no error expected")
+	assert.Contains(t, mock.Logs(), "MergeRequest called")
+}

--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -6,14 +6,16 @@ import (
 
 func newPrCmd(ctx *Context) *cobra.Command {
 	fixes := false
+	target := ""
 	command := &cobra.Command{
 		Use:     "pull-request",
 		Aliases: []string{"pr"},
 		Short:   "Create a PR based on changes in the current branch",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return ctx.Assistant.PullRequest(fixes)
+			return ctx.Assistant.PullRequest(fixes, target)
 		},
 	}
 	command.Flags().BoolVarP(&fixes, "fixes", "f", false, "Create a PR with 'fixes' keyword")
+	command.Flags().StringVarP(&target, "target", "t", "", "Target branch for the PR")
 	return command
 }

--- a/cmd/pr_test.go
+++ b/cmd/pr_test.go
@@ -31,3 +31,15 @@ func TestPr_Execution(t *testing.T) {
 	require.NoError(t, err, "no error expected")
 	assert.Contains(t, mock.Logs(), "PullRequest called")
 }
+
+func TestPr_ExecutionWithTarget(t *testing.T) {
+	mock := aidy.NewMock()
+	ctx := &Context{Assistant: mock}
+	command := newPrCmd(ctx)
+	command.SetArgs([]string{"--target", "develop"})
+
+	err := command.Execute()
+
+	require.NoError(t, err, "no error expected")
+	assert.Contains(t, mock.Logs(), "PullRequest called")
+}

--- a/internal/aidy/aidy.go
+++ b/internal/aidy/aidy.go
@@ -5,8 +5,8 @@ type Aidy interface {
 	PrintConfig() error
 	Commit(issue bool) error
 	Squash(issue bool)
-	PullRequest(fixes bool) error
-	MergeRequest(fixes bool) error
+	PullRequest(fixes bool, target string) error
+	MergeRequest(fixes bool, target string) error
 	Issue(task string) error
 	Heal() error
 	Append()

--- a/internal/aidy/mock.go
+++ b/internal/aidy/mock.go
@@ -32,12 +32,12 @@ func (m *Mock) Squash(issue bool) {
 	m.logs = append(m.logs, "Squash called")
 }
 
-func (m *Mock) PullRequest(fixes bool) error {
+func (m *Mock) PullRequest(fixes bool, target string) error {
 	m.logs = append(m.logs, "PullRequest called")
 	return nil
 }
 
-func (m *Mock) MergeRequest(fixes bool) error {
+func (m *Mock) MergeRequest(fixes bool, target string) error {
 	m.logs = append(m.logs, "MergeRequest called")
 	return nil
 }
@@ -84,11 +84,11 @@ func (f *FailingMock) Release(interval string, repo string) error   { return err
 func (f *FailingMock) PrintConfig() error                           { return errors.New("error") }
 func (f *FailingMock) Commit(issue bool) error                      { return errors.New("error") }
 func (f *FailingMock) Squash(issue bool)                            {}
-func (f *FailingMock) PullRequest(fixes bool) error                 { return errors.New("error") }
-func (f *FailingMock) MergeRequest(fixes bool) error                { return errors.New("error") }
+func (f *FailingMock) PullRequest(fixes bool, target string) error  { return errors.New("error") }
+func (f *FailingMock) MergeRequest(fixes bool, target string) error { return errors.New("error") }
 func (f *FailingMock) Issue(task string) error                      { return errors.New("error") }
-func (f *FailingMock) Heal() error                                   { return errors.New("error") }
-func (f *FailingMock) Append()                                       {}
-func (f *FailingMock) Clean()                                        {}
-func (f *FailingMock) Diff() error                                   { return errors.New("error") }
+func (f *FailingMock) Heal() error                                  { return errors.New("error") }
+func (f *FailingMock) Append()                                      {}
+func (f *FailingMock) Clean()                                       {}
+func (f *FailingMock) Diff() error                                  { return errors.New("error") }
 func (f *FailingMock) StartIssue(number string) error               { return errors.New("error") }

--- a/internal/aidy/mock_test.go
+++ b/internal/aidy/mock_test.go
@@ -36,7 +36,7 @@ func TestMockAidy_Squash(t *testing.T) {
 
 func TestMockAidy_PullRequest(t *testing.T) {
 	aidy := NewMock()
-	err := aidy.PullRequest(true)
+	err := aidy.PullRequest(true, "main")
 	require.NoError(t, err)
 	assert.Contains(t, aidy.Logs(), "PullRequest called")
 }

--- a/internal/aidy/real.go
+++ b/internal/aidy/real.go
@@ -22,8 +22,8 @@ import (
 )
 
 type real struct {
-	git    git.Git
-	github github.Github
+	git     git.Git
+	github  github.Github
 	ai      ai.AI
 	editor  output.Output
 	config  config.Config
@@ -331,7 +331,7 @@ func (r *real) print(msg string) {
 	}
 }
 
-func (r *real) PullRequest(fixes bool) error {
+func (r *real) PullRequest(fixes bool, target string) error {
 	if err := r.SetTarget(); err != nil {
 		r.logger.Warn("failed to set target repository: %v", err)
 	}
@@ -373,13 +373,17 @@ func (r *real) PullRequest(fixes bool) error {
 	} else {
 		repo = ""
 	}
+	var base string
+	if target != "" {
+		base = " --base " + target
+	}
 	prtitle := healPRTitle(healQuotes(title), nissue)
 	prbody := healQuotes(body)
-	cmd := escapeBackticks(fmt.Sprintf("gh pr create --title \"%s\" --body \"%s\"%s", prtitle, prbody, repo))
+	cmd := escapeBackticks(fmt.Sprintf("gh pr create --title \"%s\" --body \"%s\"%s%s", prtitle, prbody, repo, base))
 	return r.editor.Print(cmd)
 }
 
-func (r *real) MergeRequest(fixes bool) error {
+func (r *real) MergeRequest(fixes bool, target string) error {
 	branch, err := r.git.CurrentBranch()
 	if err != nil {
 		return fmt.Errorf("error getting branch name: %v", err)
@@ -405,9 +409,13 @@ func (r *real) MergeRequest(fixes bool) error {
 	} else {
 		body = body + fmt.Sprintf("\n\nRelated to %s", issueRef(nissue))
 	}
+	var targetBranch string
+	if target != "" {
+		targetBranch = " --target-branch " + target
+	}
 	mrtitle := healPRTitle(healQuotes(title), nissue)
 	mrbody := healQuotes(body)
-	cmd := escapeBackticks(fmt.Sprintf("glab mr create --title \"%s\" --description \"%s\"", mrtitle, mrbody))
+	cmd := escapeBackticks(fmt.Sprintf("glab mr create --title \"%s\" --description \"%s\"%s", mrtitle, mrbody, targetBranch))
 	return r.editor.Print(cmd)
 }
 

--- a/internal/aidy/real_test.go
+++ b/internal/aidy/real_test.go
@@ -562,12 +562,23 @@ func TestReal_PullRequest(t *testing.T) {
 	out := output.NewMock()
 	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github.NewMock(), editor: out, cache: cache.NewMockAidyCache(), logger: log.Default()}
 
-	err := raidy.PullRequest(false)
+	err := raidy.PullRequest(false, "")
 
 	require.NoError(t, err, "expected no error when creating pull request")
 	output := out.Last()
 	assert.Contains(t, output, "gh pr create", "Expected output to contain 'gh pr create'")
 	assert.Contains(t, output, "--title \"mock title for '#41' with issue #mock description for issue '#41' and summary: mock summary\"", "Expected output to contain title")
+}
+
+func TestReal_PullRequest_Target(t *testing.T) {
+	out := output.NewMock()
+	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github.NewMock(), editor: out, cache: cache.NewMockAidyCache(), logger: log.Default()}
+
+	err := raidy.PullRequest(false, "develop")
+
+	require.NoError(t, err, "expected no error when creating pull request with target branch")
+	output := out.Last()
+	assert.Contains(t, output, "--base develop", "Expected output to contain target branch")
 }
 
 func TestReal_PullRequest_IssueNotFound(t *testing.T) {
@@ -576,7 +587,7 @@ func TestReal_PullRequest_IssueNotFound(t *testing.T) {
 	out := output.NewMock()
 	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github, editor: out, cache: cache.NewMockAidyCache(), logger: log.NewMock()}
 
-	err := raidy.PullRequest(false)
+	err := raidy.PullRequest(false, "")
 
 	require.NoError(t, err, "Expected no error when creating pull request with issue not found")
 	output := out.Last()
@@ -591,7 +602,7 @@ func TestReal_PullRequest_Fixes(t *testing.T) {
 	out := output.NewMock()
 	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github, editor: out, cache: cache.NewMockAidyCache(), logger: log.NewMock()}
 
-	err := raidy.PullRequest(true)
+	err := raidy.PullRequest(true, "")
 
 	require.NoError(t, err, "Expected no error when creating pull request with issue not found")
 	output := out.Last()
@@ -602,7 +613,7 @@ func TestReal_MergeRequest(t *testing.T) {
 	out := output.NewMock()
 	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github.NewMock(), editor: out, cache: cache.NewMockAidyCache(), logger: log.Default()}
 
-	err := raidy.MergeRequest(false)
+	err := raidy.MergeRequest(false, "")
 
 	require.NoError(t, err, "expected no error when creating merge request")
 	result := out.Last()
@@ -610,11 +621,22 @@ func TestReal_MergeRequest(t *testing.T) {
 	assert.Contains(t, result, "Related to #")
 }
 
+func TestReal_MergeRequest_Target(t *testing.T) {
+	out := output.NewMock()
+	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github.NewMock(), editor: out, cache: cache.NewMockAidyCache(), logger: log.Default()}
+
+	err := raidy.MergeRequest(false, "develop")
+
+	require.NoError(t, err, "expected no error when creating merge request with target branch")
+	result := out.Last()
+	assert.Contains(t, result, "--target-branch develop", "Expected output to contain target branch")
+}
+
 func TestReal_MergeRequest_Fixes(t *testing.T) {
 	out := output.NewMock()
 	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github.NewMock(), editor: out, cache: cache.NewMockAidyCache(), logger: log.NewMock()}
 
-	err := raidy.MergeRequest(true)
+	err := raidy.MergeRequest(true, "")
 
 	require.NoError(t, err, "expected no error when creating merge request with fixes")
 	result := out.Last()


### PR DESCRIPTION
Add `--target`/`-t` flag to `pr` and `mr` commands to allow specifying the base/target branch, appending `--base` to `gh pr create` and `--target-branch` to `glab mr create`.

Fixes #296