### PR TITLE
feat(#299): add --duplicate flag to pr and mr commands

### DIFF
--- a/cmd/mr.go
+++ b/cmd/mr.go
@@ -7,15 +7,17 @@ import (
 func newMrCmd(ctx *Context) *cobra.Command {
 	fixes := false
 	target := ""
+	duplicate := false
 	command := &cobra.Command{
 		Use:     "merge-request",
 		Aliases: []string{"mr"},
 		Short:   "Create a MR based on changes in the current branch",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return ctx.Assistant.MergeRequest(fixes, target)
+			return ctx.Assistant.MergeRequest(fixes, target, duplicate)
 		},
 	}
 	command.Flags().BoolVarP(&fixes, "fixes", "f", false, "Create a MR with 'fixes' keyword")
 	command.Flags().StringVarP(&target, "target", "t", "", "Target branch for the MR")
+	command.Flags().BoolVar(&duplicate, "duplicate", false, "Reuse the existing MR's title and body against --target")
 	return command
 }

--- a/cmd/mr_test.go
+++ b/cmd/mr_test.go
@@ -43,3 +43,15 @@ func TestMr_ExecutionWithTarget(t *testing.T) {
 	require.NoError(t, err, "no error expected")
 	assert.Contains(t, mock.Logs(), "MergeRequest called")
 }
+
+func TestMr_ExecutionWithDuplicate(t *testing.T) {
+	mock := aidy.NewMock()
+	ctx := &Context{Assistant: mock}
+	command := newMrCmd(ctx)
+	command.SetArgs([]string{"--target", "develop", "--duplicate"})
+
+	err := command.Execute()
+
+	require.NoError(t, err, "no error expected")
+	assert.Contains(t, mock.Logs(), "MergeRequest called")
+}

--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -7,15 +7,17 @@ import (
 func newPrCmd(ctx *Context) *cobra.Command {
 	fixes := false
 	target := ""
+	duplicate := false
 	command := &cobra.Command{
 		Use:     "pull-request",
 		Aliases: []string{"pr"},
 		Short:   "Create a PR based on changes in the current branch",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return ctx.Assistant.PullRequest(fixes, target)
+			return ctx.Assistant.PullRequest(fixes, target, duplicate)
 		},
 	}
 	command.Flags().BoolVarP(&fixes, "fixes", "f", false, "Create a PR with 'fixes' keyword")
 	command.Flags().StringVarP(&target, "target", "t", "", "Target branch for the PR")
+	command.Flags().BoolVar(&duplicate, "duplicate", false, "Reuse the existing PR's title and body against --target")
 	return command
 }

--- a/cmd/pr_test.go
+++ b/cmd/pr_test.go
@@ -43,3 +43,15 @@ func TestPr_ExecutionWithTarget(t *testing.T) {
 	require.NoError(t, err, "no error expected")
 	assert.Contains(t, mock.Logs(), "PullRequest called")
 }
+
+func TestPr_ExecutionWithDuplicate(t *testing.T) {
+	mock := aidy.NewMock()
+	ctx := &Context{Assistant: mock}
+	command := newPrCmd(ctx)
+	command.SetArgs([]string{"--target", "develop", "--duplicate"})
+
+	err := command.Execute()
+
+	require.NoError(t, err, "no error expected")
+	assert.Contains(t, mock.Logs(), "PullRequest called")
+}

--- a/internal/aidy/aidy.go
+++ b/internal/aidy/aidy.go
@@ -5,8 +5,8 @@ type Aidy interface {
 	PrintConfig() error
 	Commit(issue bool) error
 	Squash(issue bool)
-	PullRequest(fixes bool, target string) error
-	MergeRequest(fixes bool, target string) error
+	PullRequest(fixes bool, target string, duplicate bool) error
+	MergeRequest(fixes bool, target string, duplicate bool) error
 	Issue(task string) error
 	Heal() error
 	Append()

--- a/internal/aidy/mock.go
+++ b/internal/aidy/mock.go
@@ -32,12 +32,12 @@ func (m *Mock) Squash(issue bool) {
 	m.logs = append(m.logs, "Squash called")
 }
 
-func (m *Mock) PullRequest(fixes bool, target string) error {
+func (m *Mock) PullRequest(fixes bool, target string, duplicate bool) error {
 	m.logs = append(m.logs, "PullRequest called")
 	return nil
 }
 
-func (m *Mock) MergeRequest(fixes bool, target string) error {
+func (m *Mock) MergeRequest(fixes bool, target string, duplicate bool) error {
 	m.logs = append(m.logs, "MergeRequest called")
 	return nil
 }
@@ -84,8 +84,12 @@ func (f *FailingMock) Release(interval string, repo string) error   { return err
 func (f *FailingMock) PrintConfig() error                           { return errors.New("error") }
 func (f *FailingMock) Commit(issue bool) error                      { return errors.New("error") }
 func (f *FailingMock) Squash(issue bool)                            {}
-func (f *FailingMock) PullRequest(fixes bool, target string) error  { return errors.New("error") }
-func (f *FailingMock) MergeRequest(fixes bool, target string) error { return errors.New("error") }
+func (f *FailingMock) PullRequest(fixes bool, target string, duplicate bool) error {
+	return errors.New("error")
+}
+func (f *FailingMock) MergeRequest(fixes bool, target string, duplicate bool) error {
+	return errors.New("error")
+}
 func (f *FailingMock) Issue(task string) error                      { return errors.New("error") }
 func (f *FailingMock) Heal() error                                  { return errors.New("error") }
 func (f *FailingMock) Append()                                      {}

--- a/internal/aidy/mock_test.go
+++ b/internal/aidy/mock_test.go
@@ -36,7 +36,7 @@ func TestMockAidy_Squash(t *testing.T) {
 
 func TestMockAidy_PullRequest(t *testing.T) {
 	aidy := NewMock()
-	err := aidy.PullRequest(true, "main")
+	err := aidy.PullRequest(true, "main", false)
 	require.NoError(t, err)
 	assert.Contains(t, aidy.Logs(), "PullRequest called")
 }

--- a/internal/aidy/real.go
+++ b/internal/aidy/real.go
@@ -16,6 +16,7 @@ import (
 	"github.com/volodya-lombrozo/aidy/internal/executor"
 	"github.com/volodya-lombrozo/aidy/internal/git"
 	"github.com/volodya-lombrozo/aidy/internal/github"
+	"github.com/volodya-lombrozo/aidy/internal/gitlab"
 	"github.com/volodya-lombrozo/aidy/internal/log"
 	"github.com/volodya-lombrozo/aidy/internal/output"
 	"golang.org/x/mod/semver"
@@ -24,6 +25,7 @@ import (
 type real struct {
 	git     git.Git
 	github  github.Github
+	gitlab  gitlab.Gitlab
 	ai      ai.AI
 	editor  output.Output
 	config  config.Config
@@ -75,6 +77,7 @@ func NewAidy(summary bool, aider bool, ailess bool, silent bool, debug bool, lan
 		aidy.logger.Error("failed to initialize GitHub client: %v", err)
 		os.Exit(1)
 	}
+	aidy.gitlab = gitlab.NewGitlab(shell)
 	if err = aidy.InitSummary(summary, "README.md"); err != nil {
 		aidy.logger.Warn("failed to initialize project summary: %v", err)
 	}
@@ -331,7 +334,10 @@ func (r *real) print(msg string) {
 	}
 }
 
-func (r *real) PullRequest(fixes bool, target string) error {
+func (r *real) PullRequest(fixes bool, target string, duplicate bool) error {
+	if duplicate && target == "" {
+		return fmt.Errorf("--duplicate requires --target to specify the branch to duplicate the pull request against")
+	}
 	if err := r.SetTarget(); err != nil {
 		r.logger.Warn("failed to set target repository: %v", err)
 	}
@@ -339,32 +345,41 @@ func (r *real) PullRequest(fixes bool, target string) error {
 	if err != nil {
 		return fmt.Errorf("error getting branch name: %v", err)
 	}
-	diff, err := r.git.Diff()
-	if err != nil {
-		return fmt.Errorf("error getting git diff: %v", err)
-	}
-	summary, _ := r.cache.Summary()
 	nissue := inumber(branch)
-	r.logger.Info("retrieving the description for issue #%s...", nissue)
-	issue, err := r.github.Description(nissue)
-	if err != nil {
-		issue = "not-found"
-		r.logger.Warn("issue description not found for issue #%s because of %v, using default value", nissue, err)
-	}
-	r.logger.Info("generating pull request title...")
-	title, err := r.ai.PrTitle(issueRef(nissue), diff, issue, summary)
-	if err != nil {
-		return fmt.Errorf("error generating pull request title: %v", err)
-	}
-	r.logger.Info("generating pull request body...")
-	body, err := r.ai.PrBody(diff, issue, summary)
-	if err != nil {
-		return fmt.Errorf("error generating pull request body: %v", err)
-	}
-	if fixes {
-		body = body + fmt.Sprintf("\n\nFixes %s", issueRef(nissue))
+	var title, body string
+	if duplicate {
+		r.logger.Info("looking up the open pull request for branch '%s' to duplicate...", branch)
+		title, body, err = r.github.PullRequestByBranch(branch)
+		if err != nil {
+			return fmt.Errorf("error finding an existing pull request to duplicate: %v", err)
+		}
 	} else {
-		body = body + fmt.Sprintf("\n\nRelated to %s", issueRef(nissue))
+		diff, err := r.git.Diff()
+		if err != nil {
+			return fmt.Errorf("error getting git diff: %v", err)
+		}
+		summary, _ := r.cache.Summary()
+		r.logger.Info("retrieving the description for issue #%s...", nissue)
+		issue, err := r.github.Description(nissue)
+		if err != nil {
+			issue = "not-found"
+			r.logger.Warn("issue description not found for issue #%s because of %v, using default value", nissue, err)
+		}
+		r.logger.Info("generating pull request title...")
+		title, err = r.ai.PrTitle(issueRef(nissue), diff, issue, summary)
+		if err != nil {
+			return fmt.Errorf("error generating pull request title: %v", err)
+		}
+		r.logger.Info("generating pull request body...")
+		body, err = r.ai.PrBody(diff, issue, summary)
+		if err != nil {
+			return fmt.Errorf("error generating pull request body: %v", err)
+		}
+		if fixes {
+			body = body + fmt.Sprintf("\n\nFixes %s", issueRef(nissue))
+		} else {
+			body = body + fmt.Sprintf("\n\nRelated to %s", issueRef(nissue))
+		}
 	}
 	remote := r.cache.Remote()
 	var repo string
@@ -383,31 +398,43 @@ func (r *real) PullRequest(fixes bool, target string) error {
 	return r.editor.Print(cmd)
 }
 
-func (r *real) MergeRequest(fixes bool, target string) error {
+func (r *real) MergeRequest(fixes bool, target string, duplicate bool) error {
+	if duplicate && target == "" {
+		return fmt.Errorf("--duplicate requires --target to specify the branch to duplicate the merge request against")
+	}
 	branch, err := r.git.CurrentBranch()
 	if err != nil {
 		return fmt.Errorf("error getting branch name: %v", err)
 	}
-	diff, err := r.git.Diff()
-	if err != nil {
-		return fmt.Errorf("error getting git diff: %v", err)
-	}
-	summary, _ := r.cache.Summary()
 	nissue := inumber(branch)
-	r.logger.Info("generating merge request title...")
-	title, err := r.ai.PrTitle(issueRef(nissue), diff, "", summary)
-	if err != nil {
-		return fmt.Errorf("error generating merge request title: %v", err)
-	}
-	r.logger.Info("generating merge request body...")
-	body, err := r.ai.PrBody(diff, "", summary)
-	if err != nil {
-		return fmt.Errorf("error generating merge request body: %v", err)
-	}
-	if fixes {
-		body = body + fmt.Sprintf("\n\nCloses %s", issueRef(nissue))
+	var title, body string
+	if duplicate {
+		r.logger.Info("looking up the open merge request for branch '%s' to duplicate...", branch)
+		title, body, err = r.gitlab.MergeRequestByBranch(branch)
+		if err != nil {
+			return fmt.Errorf("error finding an existing merge request to duplicate: %v", err)
+		}
 	} else {
-		body = body + fmt.Sprintf("\n\nRelated to %s", issueRef(nissue))
+		diff, err := r.git.Diff()
+		if err != nil {
+			return fmt.Errorf("error getting git diff: %v", err)
+		}
+		summary, _ := r.cache.Summary()
+		r.logger.Info("generating merge request title...")
+		title, err = r.ai.PrTitle(issueRef(nissue), diff, "", summary)
+		if err != nil {
+			return fmt.Errorf("error generating merge request title: %v", err)
+		}
+		r.logger.Info("generating merge request body...")
+		body, err = r.ai.PrBody(diff, "", summary)
+		if err != nil {
+			return fmt.Errorf("error generating merge request body: %v", err)
+		}
+		if fixes {
+			body = body + fmt.Sprintf("\n\nCloses %s", issueRef(nissue))
+		} else {
+			body = body + fmt.Sprintf("\n\nRelated to %s", issueRef(nissue))
+		}
 	}
 	var targetBranch string
 	if target != "" {

--- a/internal/aidy/real_test.go
+++ b/internal/aidy/real_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/volodya-lombrozo/aidy/internal/executor"
 	"github.com/volodya-lombrozo/aidy/internal/git"
 	"github.com/volodya-lombrozo/aidy/internal/github"
+	"github.com/volodya-lombrozo/aidy/internal/gitlab"
 	"github.com/volodya-lombrozo/aidy/internal/log"
 	"github.com/volodya-lombrozo/aidy/internal/output"
 )
@@ -562,7 +563,7 @@ func TestReal_PullRequest(t *testing.T) {
 	out := output.NewMock()
 	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github.NewMock(), editor: out, cache: cache.NewMockAidyCache(), logger: log.Default()}
 
-	err := raidy.PullRequest(false, "")
+	err := raidy.PullRequest(false, "", false)
 
 	require.NoError(t, err, "expected no error when creating pull request")
 	output := out.Last()
@@ -574,7 +575,7 @@ func TestReal_PullRequest_Target(t *testing.T) {
 	out := output.NewMock()
 	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github.NewMock(), editor: out, cache: cache.NewMockAidyCache(), logger: log.Default()}
 
-	err := raidy.PullRequest(false, "develop")
+	err := raidy.PullRequest(false, "develop", false)
 
 	require.NoError(t, err, "expected no error when creating pull request with target branch")
 	output := out.Last()
@@ -587,7 +588,7 @@ func TestReal_PullRequest_IssueNotFound(t *testing.T) {
 	out := output.NewMock()
 	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github, editor: out, cache: cache.NewMockAidyCache(), logger: log.NewMock()}
 
-	err := raidy.PullRequest(false, "")
+	err := raidy.PullRequest(false, "", false)
 
 	require.NoError(t, err, "Expected no error when creating pull request with issue not found")
 	output := out.Last()
@@ -602,18 +603,54 @@ func TestReal_PullRequest_Fixes(t *testing.T) {
 	out := output.NewMock()
 	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github, editor: out, cache: cache.NewMockAidyCache(), logger: log.NewMock()}
 
-	err := raidy.PullRequest(true, "")
+	err := raidy.PullRequest(true, "", false)
 
 	require.NoError(t, err, "Expected no error when creating pull request with issue not found")
 	output := out.Last()
 	assert.Contains(t, output, "Fixes #")
 }
 
+func TestReal_PullRequest_Duplicate(t *testing.T) {
+	out := output.NewMock()
+	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github.NewMock(), editor: out, cache: cache.NewMockAidyCache(), logger: log.Default()}
+
+	err := raidy.PullRequest(false, "develop", true)
+
+	require.NoError(t, err, "expected no error when duplicating a pull request")
+	output := out.Last()
+	assert.Contains(t, output, "gh pr create", "Expected output to contain 'gh pr create'")
+	assert.Contains(t, output, "--base develop", "Expected output to contain target branch")
+	assert.Contains(t, output, "mock title for branch", "Expected output to reuse the existing pull request title")
+	assert.Contains(t, output, "mock body for branch", "Expected output to reuse the existing pull request body")
+}
+
+func TestReal_PullRequest_Duplicate_NoTarget(t *testing.T) {
+	out := output.NewMock()
+	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github.NewMock(), editor: out, cache: cache.NewMockAidyCache(), logger: log.Default()}
+
+	err := raidy.PullRequest(false, "", true)
+
+	require.Error(t, err, "expected an error when duplicating a pull request without a target branch")
+	assert.Contains(t, err.Error(), "--duplicate requires --target")
+}
+
+func TestReal_PullRequest_Duplicate_NotFound(t *testing.T) {
+	github := github.NewMock()
+	github.Error = fmt.Errorf("no open pull request found for branch 'feature'")
+	out := output.NewMock()
+	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github, editor: out, cache: cache.NewMockAidyCache(), logger: log.Default()}
+
+	err := raidy.PullRequest(false, "develop", true)
+
+	require.Error(t, err, "expected an error when there is no pull request to duplicate")
+	assert.Contains(t, err.Error(), "error finding an existing pull request to duplicate")
+}
+
 func TestReal_MergeRequest(t *testing.T) {
 	out := output.NewMock()
 	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github.NewMock(), editor: out, cache: cache.NewMockAidyCache(), logger: log.Default()}
 
-	err := raidy.MergeRequest(false, "")
+	err := raidy.MergeRequest(false, "", false)
 
 	require.NoError(t, err, "expected no error when creating merge request")
 	result := out.Last()
@@ -625,7 +662,7 @@ func TestReal_MergeRequest_Target(t *testing.T) {
 	out := output.NewMock()
 	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github.NewMock(), editor: out, cache: cache.NewMockAidyCache(), logger: log.Default()}
 
-	err := raidy.MergeRequest(false, "develop")
+	err := raidy.MergeRequest(false, "develop", false)
 
 	require.NoError(t, err, "expected no error when creating merge request with target branch")
 	result := out.Last()
@@ -636,12 +673,48 @@ func TestReal_MergeRequest_Fixes(t *testing.T) {
 	out := output.NewMock()
 	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github.NewMock(), editor: out, cache: cache.NewMockAidyCache(), logger: log.NewMock()}
 
-	err := raidy.MergeRequest(true, "")
+	err := raidy.MergeRequest(true, "", false)
 
 	require.NoError(t, err, "expected no error when creating merge request with fixes")
 	result := out.Last()
 	assert.Contains(t, result, "glab mr create")
 	assert.Contains(t, result, "Closes #")
+}
+
+func TestReal_MergeRequest_Duplicate(t *testing.T) {
+	out := output.NewMock()
+	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github.NewMock(), gitlab: gitlab.NewMock(), editor: out, cache: cache.NewMockAidyCache(), logger: log.Default()}
+
+	err := raidy.MergeRequest(false, "develop", true)
+
+	require.NoError(t, err, "expected no error when duplicating a merge request")
+	result := out.Last()
+	assert.Contains(t, result, "glab mr create", "Expected output to contain 'glab mr create'")
+	assert.Contains(t, result, "--target-branch develop", "Expected output to contain target branch")
+	assert.Contains(t, result, "mock title for branch", "Expected output to reuse the existing merge request title")
+	assert.Contains(t, result, "mock body for branch", "Expected output to reuse the existing merge request body")
+}
+
+func TestReal_MergeRequest_Duplicate_NoTarget(t *testing.T) {
+	out := output.NewMock()
+	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github.NewMock(), gitlab: gitlab.NewMock(), editor: out, cache: cache.NewMockAidyCache(), logger: log.Default()}
+
+	err := raidy.MergeRequest(false, "", true)
+
+	require.Error(t, err, "expected an error when duplicating a merge request without a target branch")
+	assert.Contains(t, err.Error(), "--duplicate requires --target")
+}
+
+func TestReal_MergeRequest_Duplicate_NotFound(t *testing.T) {
+	gl := gitlab.NewMock()
+	gl.Error = fmt.Errorf("no open merge request found for branch 'feature'")
+	out := output.NewMock()
+	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github.NewMock(), gitlab: gl, editor: out, cache: cache.NewMockAidyCache(), logger: log.Default()}
+
+	err := raidy.MergeRequest(false, "develop", true)
+
+	require.Error(t, err, "expected an error when there is no merge request to duplicate")
+	assert.Contains(t, err.Error(), "error finding an existing merge request to duplicate")
 }
 
 func TestReal_Commit(t *testing.T) {

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -4,4 +4,5 @@ type Github interface {
 	Description(number string) (string, error)
 	Labels() ([]string, error)
 	Remotes() ([]string, error)
+	PullRequestByBranch(branch string) (title string, body string, err error)
 }

--- a/internal/github/mock.go
+++ b/internal/github/mock.go
@@ -21,3 +21,7 @@ func (m *MockGithub) Labels() ([]string, error) {
 func (m *MockGithub) Remotes() ([]string, error) {
 	return []string{"volodya-lombrozo/aidy", "volodya-lombrozo/jtcop"}, m.Error
 }
+
+func (m *MockGithub) PullRequestByBranch(branch string) (string, string, error) {
+	return fmt.Sprintf("mock title for branch '%s'", branch), fmt.Sprintf("mock body for branch '%s'", branch), m.Error
+}

--- a/internal/github/real.go
+++ b/internal/github/real.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/volodya-lombrozo/aidy/internal/cache"
 	"github.com/volodya-lombrozo/aidy/internal/git"
@@ -35,6 +36,12 @@ type label struct {
 	Name        string `json:"name"`
 	Color       string `json:"color"`
 	Description string `json:"description"`
+}
+
+type pullRequest struct {
+	Number int    `json:"number"`
+	Title  string `json:"title"`
+	Body   string `json:"body"`
 }
 
 func NewGithub(url string, gs git.Git, token string, ch cache.AidyCache) *github {
@@ -112,6 +119,46 @@ func (r *github) Labels() ([]string, error) {
 		res = append(res, label.Name)
 	}
 	return res, nil
+}
+
+func (r *github) PullRequestByBranch(branch string) (string, string, error) {
+	target := r.ch.Remote()
+	if target == "" {
+		return "", "", fmt.Errorf("cannot find a target repository to search for an open pull request for branch '%s'", branch)
+	}
+	owner := strings.SplitN(target, "/", 2)[0]
+	url := fmt.Sprintf("%s/repos/%s/pulls?head=%s:%s&state=open", r.url, target, owner, branch)
+	r.log.Debug("trying to find an open pull request using the following url: %s", url)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return "", "", fmt.Errorf("cannot create a new GET request to find a pull request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+r.token)
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return "", "", fmt.Errorf("error fetching pull request for branch '%s': %w", branch, err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			r.log.Error("error closing response body: %v", err)
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("cannot find a pull request using the following url: '%s'. response: '%s'", url, resp.Status)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", "", fmt.Errorf("error reading response body: %w", err)
+	}
+	var prs []pullRequest
+	if err := json.Unmarshal(body, &prs); err != nil {
+		return "", "", fmt.Errorf("error unmarshaling pull requests json: %w", err)
+	}
+	if len(prs) == 0 {
+		return "", "", fmt.Errorf("no open pull request found for branch '%s'", branch)
+	}
+	r.log.Debug("found an open pull request #%d for branch '%s'", prs[0].Number, branch)
+	return prs[0].Title, prs[0].Body, nil
 }
 
 func (r *github) Remotes() ([]string, error) {

--- a/internal/github/real_test.go
+++ b/internal/github/real_test.go
@@ -126,6 +126,61 @@ func TestRealGithub_Labels_UrlParsingError(t *testing.T) {
 	assert.Nil(t, labels, "Labels should be nil on error")
 }
 
+const JsonPullRequests = `[
+  {
+    "number": 42,
+    "title": "PR Title",
+    "body": "PR Body"
+  }
+]`
+
+func TestRealGithub_PullRequestByBranch(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte(JsonPullRequests)); err != nil {
+			t.Errorf("Error writing response: %v", err)
+		}
+	}))
+	defer ts.Close()
+	gh := NewGithub(ts.URL, git.NewMock(), "", cache.NewMockAidyCache())
+
+	title, body, err := gh.PullRequestByBranch("feature-branch")
+
+	require.NoError(t, err, "PullRequestByBranch should not return an error")
+	assert.Equal(t, "PR Title", title)
+	assert.Equal(t, "PR Body", body)
+}
+
+func TestRealGithub_PullRequestByBranch_NotFound(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte("[]")); err != nil {
+			t.Errorf("Error writing response: %v", err)
+		}
+	}))
+	defer ts.Close()
+	gh := NewGithub(ts.URL, git.NewMock(), "", cache.NewMockAidyCache())
+
+	title, body, err := gh.PullRequestByBranch("feature-branch")
+
+	require.Error(t, err, "PullRequestByBranch should return an error when no PR is found")
+	assert.Contains(t, err.Error(), "no open pull request found for branch 'feature-branch'")
+	assert.Empty(t, title)
+	assert.Empty(t, body)
+}
+
+func TestRealGithub_PullRequestByBranch_NoRemote(t *testing.T) {
+	gh := NewGithub("http://example.com", git.NewMock(), "", cache.NewMockAidyCache())
+	gh.ch.WithRemote("")
+
+	title, body, err := gh.PullRequestByBranch("feature-branch")
+
+	require.Error(t, err, "PullRequestByBranch should return an error when no remote is set")
+	assert.Contains(t, err.Error(), "cannot find a target repository to search for an open pull request for branch 'feature-branch'")
+	assert.Empty(t, title)
+	assert.Empty(t, body)
+}
+
 func TestRealGithub_Labels_InvalidProtocol(t *testing.T) {
 	gh := NewGithub("invalid://protocol", git.NewMock(), "", cache.NewMockAidyCache())
 	gh.ch.WithRemote("invalid-protocol")

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -1,0 +1,5 @@
+package gitlab
+
+type Gitlab interface {
+	MergeRequestByBranch(branch string) (title string, body string, err error)
+}

--- a/internal/gitlab/mock.go
+++ b/internal/gitlab/mock.go
@@ -1,0 +1,15 @@
+package gitlab
+
+import "fmt"
+
+type MockGitlab struct {
+	Error error
+}
+
+func NewMock() *MockGitlab {
+	return &MockGitlab{Error: nil}
+}
+
+func (m *MockGitlab) MergeRequestByBranch(branch string) (string, string, error) {
+	return fmt.Sprintf("mock title for branch '%s'", branch), fmt.Sprintf("mock body for branch '%s'", branch), m.Error
+}

--- a/internal/gitlab/real.go
+++ b/internal/gitlab/real.go
@@ -1,0 +1,39 @@
+package gitlab
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/volodya-lombrozo/aidy/internal/executor"
+	"github.com/volodya-lombrozo/aidy/internal/log"
+)
+
+type real struct {
+	shell executor.Executor
+	log   log.Logger
+}
+
+type mergeRequest struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+}
+
+func NewGitlab(shell executor.Executor) *real {
+	return &real{shell: shell, log: log.Default()}
+}
+
+func (r *real) MergeRequestByBranch(branch string) (string, string, error) {
+	out, err := r.shell.RunCommand("glab", "mr", "view", branch, "--output", "json")
+	if err != nil {
+		return "", "", fmt.Errorf("error fetching merge request for branch '%s': %w", branch, err)
+	}
+	var mr mergeRequest
+	if err := json.Unmarshal([]byte(out), &mr); err != nil {
+		return "", "", fmt.Errorf("error parsing merge request json for branch '%s': %w", branch, err)
+	}
+	if mr.Title == "" {
+		return "", "", fmt.Errorf("no open merge request found for branch '%s'", branch)
+	}
+	r.log.Debug("found an open merge request '%s' for branch '%s'", mr.Title, branch)
+	return mr.Title, mr.Description, nil
+}

--- a/internal/gitlab/real_test.go
+++ b/internal/gitlab/real_test.go
@@ -1,0 +1,61 @@
+package gitlab
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/volodya-lombrozo/aidy/internal/executor"
+)
+
+func TestReal_MergeRequestByBranch(t *testing.T) {
+	shell := executor.NewMock()
+	shell.Output = `{"title": "MR Title", "description": "MR Body"}`
+	gl := NewGitlab(shell)
+
+	title, body, err := gl.MergeRequestByBranch("feature-branch")
+
+	require.NoError(t, err, "MergeRequestByBranch should not return an error")
+	assert.Equal(t, "MR Title", title)
+	assert.Equal(t, "MR Body", body)
+	assert.Contains(t, shell.Commands[0], "glab mr view feature-branch --output json")
+}
+
+func TestReal_MergeRequestByBranch_NotFound(t *testing.T) {
+	shell := executor.NewMock()
+	shell.Output = `{}`
+	gl := NewGitlab(shell)
+
+	title, body, err := gl.MergeRequestByBranch("feature-branch")
+
+	require.Error(t, err, "MergeRequestByBranch should return an error when no MR is found")
+	assert.Contains(t, err.Error(), "no open merge request found for branch 'feature-branch'")
+	assert.Empty(t, title)
+	assert.Empty(t, body)
+}
+
+func TestReal_MergeRequestByBranch_CommandError(t *testing.T) {
+	shell := executor.NewMock()
+	shell.Err = assert.AnError
+	gl := NewGitlab(shell)
+
+	title, body, err := gl.MergeRequestByBranch("feature-branch")
+
+	require.Error(t, err, "MergeRequestByBranch should return an error when the command fails")
+	assert.Contains(t, err.Error(), "error fetching merge request for branch 'feature-branch'")
+	assert.Empty(t, title)
+	assert.Empty(t, body)
+}
+
+func TestReal_MergeRequestByBranch_InvalidJson(t *testing.T) {
+	shell := executor.NewMock()
+	shell.Output = "not-json"
+	gl := NewGitlab(shell)
+
+	title, body, err := gl.MergeRequestByBranch("feature-branch")
+
+	require.Error(t, err, "MergeRequestByBranch should return an error when the json is invalid")
+	assert.Contains(t, err.Error(), "error parsing merge request json for branch 'feature-branch'")
+	assert.Empty(t, title)
+	assert.Empty(t, body)
+}


### PR DESCRIPTION
Adds a `--duplicate` flag to the `pr` and `mr` commands that reuses an existing PR/MR title and body to open it against a different `--target` branch.

Fixes #299