### PR TITLE
feat(#301): add `--source` flag to `--duplicate` for PR and MR commands

### DIFF
--- a/cmd/mr.go
+++ b/cmd/mr.go
@@ -8,16 +8,18 @@ func newMrCmd(ctx *Context) *cobra.Command {
 	fixes := false
 	target := ""
 	duplicate := false
+	source := ""
 	command := &cobra.Command{
 		Use:     "merge-request",
 		Aliases: []string{"mr"},
 		Short:   "Create a MR based on changes in the current branch",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return ctx.Assistant.MergeRequest(fixes, target, duplicate)
+			return ctx.Assistant.MergeRequest(fixes, target, duplicate, source)
 		},
 	}
 	command.Flags().BoolVarP(&fixes, "fixes", "f", false, "Create a MR with 'fixes' keyword")
 	command.Flags().StringVarP(&target, "target", "t", "", "Target branch for the MR")
-	command.Flags().BoolVar(&duplicate, "duplicate", false, "Reuse the existing MR's title and body against --target")
+	command.Flags().BoolVar(&duplicate, "duplicate", false, "Reuse an existing MR's title and body against --target")
+	command.Flags().StringVar(&source, "source", "", "Branch whose existing MR to duplicate (defaults to the current branch)")
 	return command
 }

--- a/cmd/mr_test.go
+++ b/cmd/mr_test.go
@@ -55,3 +55,15 @@ func TestMr_ExecutionWithDuplicate(t *testing.T) {
 	require.NoError(t, err, "no error expected")
 	assert.Contains(t, mock.Logs(), "MergeRequest called")
 }
+
+func TestMr_ExecutionWithDuplicateSource(t *testing.T) {
+	mock := aidy.NewMock()
+	ctx := &Context{Assistant: mock}
+	command := newMrCmd(ctx)
+	command.SetArgs([]string{"--target", "develop", "--duplicate", "--source", "feature-x"})
+
+	err := command.Execute()
+
+	require.NoError(t, err, "no error expected")
+	assert.Contains(t, mock.Logs(), "MergeRequest called")
+}

--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -8,16 +8,18 @@ func newPrCmd(ctx *Context) *cobra.Command {
 	fixes := false
 	target := ""
 	duplicate := false
+	source := ""
 	command := &cobra.Command{
 		Use:     "pull-request",
 		Aliases: []string{"pr"},
 		Short:   "Create a PR based on changes in the current branch",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return ctx.Assistant.PullRequest(fixes, target, duplicate)
+			return ctx.Assistant.PullRequest(fixes, target, duplicate, source)
 		},
 	}
 	command.Flags().BoolVarP(&fixes, "fixes", "f", false, "Create a PR with 'fixes' keyword")
 	command.Flags().StringVarP(&target, "target", "t", "", "Target branch for the PR")
-	command.Flags().BoolVar(&duplicate, "duplicate", false, "Reuse the existing PR's title and body against --target")
+	command.Flags().BoolVar(&duplicate, "duplicate", false, "Reuse an existing PR's title and body against --target")
+	command.Flags().StringVar(&source, "source", "", "Branch whose existing PR to duplicate (defaults to the current branch)")
 	return command
 }

--- a/cmd/pr_test.go
+++ b/cmd/pr_test.go
@@ -55,3 +55,15 @@ func TestPr_ExecutionWithDuplicate(t *testing.T) {
 	require.NoError(t, err, "no error expected")
 	assert.Contains(t, mock.Logs(), "PullRequest called")
 }
+
+func TestPr_ExecutionWithDuplicateSource(t *testing.T) {
+	mock := aidy.NewMock()
+	ctx := &Context{Assistant: mock}
+	command := newPrCmd(ctx)
+	command.SetArgs([]string{"--target", "develop", "--duplicate", "--source", "feature-x"})
+
+	err := command.Execute()
+
+	require.NoError(t, err, "no error expected")
+	assert.Contains(t, mock.Logs(), "PullRequest called")
+}

--- a/internal/aidy/aidy.go
+++ b/internal/aidy/aidy.go
@@ -5,8 +5,8 @@ type Aidy interface {
 	PrintConfig() error
 	Commit(issue bool) error
 	Squash(issue bool)
-	PullRequest(fixes bool, target string, duplicate bool) error
-	MergeRequest(fixes bool, target string, duplicate bool) error
+	PullRequest(fixes bool, target string, duplicate bool, source string) error
+	MergeRequest(fixes bool, target string, duplicate bool, source string) error
 	Issue(task string) error
 	Heal() error
 	Append()

--- a/internal/aidy/mock.go
+++ b/internal/aidy/mock.go
@@ -32,12 +32,12 @@ func (m *Mock) Squash(issue bool) {
 	m.logs = append(m.logs, "Squash called")
 }
 
-func (m *Mock) PullRequest(fixes bool, target string, duplicate bool) error {
+func (m *Mock) PullRequest(fixes bool, target string, duplicate bool, source string) error {
 	m.logs = append(m.logs, "PullRequest called")
 	return nil
 }
 
-func (m *Mock) MergeRequest(fixes bool, target string, duplicate bool) error {
+func (m *Mock) MergeRequest(fixes bool, target string, duplicate bool, source string) error {
 	m.logs = append(m.logs, "MergeRequest called")
 	return nil
 }
@@ -84,10 +84,10 @@ func (f *FailingMock) Release(interval string, repo string) error   { return err
 func (f *FailingMock) PrintConfig() error                           { return errors.New("error") }
 func (f *FailingMock) Commit(issue bool) error                      { return errors.New("error") }
 func (f *FailingMock) Squash(issue bool)                            {}
-func (f *FailingMock) PullRequest(fixes bool, target string, duplicate bool) error {
+func (f *FailingMock) PullRequest(fixes bool, target string, duplicate bool, source string) error {
 	return errors.New("error")
 }
-func (f *FailingMock) MergeRequest(fixes bool, target string, duplicate bool) error {
+func (f *FailingMock) MergeRequest(fixes bool, target string, duplicate bool, source string) error {
 	return errors.New("error")
 }
 func (f *FailingMock) Issue(task string) error                      { return errors.New("error") }

--- a/internal/aidy/mock_test.go
+++ b/internal/aidy/mock_test.go
@@ -36,7 +36,7 @@ func TestMockAidy_Squash(t *testing.T) {
 
 func TestMockAidy_PullRequest(t *testing.T) {
 	aidy := NewMock()
-	err := aidy.PullRequest(true, "main", false)
+	err := aidy.PullRequest(true, "main", false, "")
 	require.NoError(t, err)
 	assert.Contains(t, aidy.Logs(), "PullRequest called")
 }

--- a/internal/aidy/real.go
+++ b/internal/aidy/real.go
@@ -334,7 +334,7 @@ func (r *real) print(msg string) {
 	}
 }
 
-func (r *real) PullRequest(fixes bool, target string, duplicate bool) error {
+func (r *real) PullRequest(fixes bool, target string, duplicate bool, source string) error {
 	if duplicate && target == "" {
 		return fmt.Errorf("--duplicate requires --target to specify the branch to duplicate the pull request against")
 	}
@@ -345,11 +345,15 @@ func (r *real) PullRequest(fixes bool, target string, duplicate bool) error {
 	if err != nil {
 		return fmt.Errorf("error getting branch name: %v", err)
 	}
-	nissue := inumber(branch)
+	lookup := branch
+	if duplicate && source != "" {
+		lookup = source
+	}
+	nissue := inumber(lookup)
 	var title, body string
 	if duplicate {
-		r.logger.Info("looking up the open pull request for branch '%s' to duplicate...", branch)
-		title, body, err = r.github.PullRequestByBranch(branch)
+		r.logger.Info("looking up the open pull request for branch '%s' to duplicate...", lookup)
+		title, body, err = r.github.PullRequestByBranch(lookup)
 		if err != nil {
 			return fmt.Errorf("error finding an existing pull request to duplicate: %v", err)
 		}
@@ -398,7 +402,7 @@ func (r *real) PullRequest(fixes bool, target string, duplicate bool) error {
 	return r.editor.Print(cmd)
 }
 
-func (r *real) MergeRequest(fixes bool, target string, duplicate bool) error {
+func (r *real) MergeRequest(fixes bool, target string, duplicate bool, source string) error {
 	if duplicate && target == "" {
 		return fmt.Errorf("--duplicate requires --target to specify the branch to duplicate the merge request against")
 	}
@@ -406,11 +410,15 @@ func (r *real) MergeRequest(fixes bool, target string, duplicate bool) error {
 	if err != nil {
 		return fmt.Errorf("error getting branch name: %v", err)
 	}
-	nissue := inumber(branch)
+	lookup := branch
+	if duplicate && source != "" {
+		lookup = source
+	}
+	nissue := inumber(lookup)
 	var title, body string
 	if duplicate {
-		r.logger.Info("looking up the open merge request for branch '%s' to duplicate...", branch)
-		title, body, err = r.gitlab.MergeRequestByBranch(branch)
+		r.logger.Info("looking up the open merge request for branch '%s' to duplicate...", lookup)
+		title, body, err = r.gitlab.MergeRequestByBranch(lookup)
 		if err != nil {
 			return fmt.Errorf("error finding an existing merge request to duplicate: %v", err)
 		}

--- a/internal/aidy/real_test.go
+++ b/internal/aidy/real_test.go
@@ -563,7 +563,7 @@ func TestReal_PullRequest(t *testing.T) {
 	out := output.NewMock()
 	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github.NewMock(), editor: out, cache: cache.NewMockAidyCache(), logger: log.Default()}
 
-	err := raidy.PullRequest(false, "", false)
+	err := raidy.PullRequest(false, "", false, "")
 
 	require.NoError(t, err, "expected no error when creating pull request")
 	output := out.Last()
@@ -575,7 +575,7 @@ func TestReal_PullRequest_Target(t *testing.T) {
 	out := output.NewMock()
 	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github.NewMock(), editor: out, cache: cache.NewMockAidyCache(), logger: log.Default()}
 
-	err := raidy.PullRequest(false, "develop", false)
+	err := raidy.PullRequest(false, "develop", false, "")
 
 	require.NoError(t, err, "expected no error when creating pull request with target branch")
 	output := out.Last()
@@ -588,7 +588,7 @@ func TestReal_PullRequest_IssueNotFound(t *testing.T) {
 	out := output.NewMock()
 	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github, editor: out, cache: cache.NewMockAidyCache(), logger: log.NewMock()}
 
-	err := raidy.PullRequest(false, "", false)
+	err := raidy.PullRequest(false, "", false, "")
 
 	require.NoError(t, err, "Expected no error when creating pull request with issue not found")
 	output := out.Last()
@@ -603,7 +603,7 @@ func TestReal_PullRequest_Fixes(t *testing.T) {
 	out := output.NewMock()
 	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github, editor: out, cache: cache.NewMockAidyCache(), logger: log.NewMock()}
 
-	err := raidy.PullRequest(true, "", false)
+	err := raidy.PullRequest(true, "", false, "")
 
 	require.NoError(t, err, "Expected no error when creating pull request with issue not found")
 	output := out.Last()
@@ -614,21 +614,34 @@ func TestReal_PullRequest_Duplicate(t *testing.T) {
 	out := output.NewMock()
 	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github.NewMock(), editor: out, cache: cache.NewMockAidyCache(), logger: log.Default()}
 
-	err := raidy.PullRequest(false, "develop", true)
+	err := raidy.PullRequest(false, "develop", true, "")
 
 	require.NoError(t, err, "expected no error when duplicating a pull request")
 	output := out.Last()
 	assert.Contains(t, output, "gh pr create", "Expected output to contain 'gh pr create'")
 	assert.Contains(t, output, "--base develop", "Expected output to contain target branch")
-	assert.Contains(t, output, "mock title for branch", "Expected output to reuse the existing pull request title")
-	assert.Contains(t, output, "mock body for branch", "Expected output to reuse the existing pull request body")
+	assert.Contains(t, output, "mock title for branch '41_working_branch'", "Expected output to reuse the current branch's pull request title")
+	assert.Contains(t, output, "mock body for branch '41_working_branch'", "Expected output to reuse the current branch's pull request body")
+}
+
+func TestReal_PullRequest_Duplicate_Source(t *testing.T) {
+	out := output.NewMock()
+	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github.NewMock(), editor: out, cache: cache.NewMockAidyCache(), logger: log.Default()}
+
+	err := raidy.PullRequest(false, "develop", true, "feature-x")
+
+	require.NoError(t, err, "expected no error when duplicating a pull request from a given source branch")
+	output := out.Last()
+	assert.Contains(t, output, "--base develop", "Expected output to contain target branch")
+	assert.Contains(t, output, "mock title for branch 'feature-x'", "Expected output to reuse the source branch's pull request title")
+	assert.Contains(t, output, "mock body for branch 'feature-x'", "Expected output to reuse the source branch's pull request body")
 }
 
 func TestReal_PullRequest_Duplicate_NoTarget(t *testing.T) {
 	out := output.NewMock()
 	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github.NewMock(), editor: out, cache: cache.NewMockAidyCache(), logger: log.Default()}
 
-	err := raidy.PullRequest(false, "", true)
+	err := raidy.PullRequest(false, "", true, "")
 
 	require.Error(t, err, "expected an error when duplicating a pull request without a target branch")
 	assert.Contains(t, err.Error(), "--duplicate requires --target")
@@ -640,7 +653,7 @@ func TestReal_PullRequest_Duplicate_NotFound(t *testing.T) {
 	out := output.NewMock()
 	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github, editor: out, cache: cache.NewMockAidyCache(), logger: log.Default()}
 
-	err := raidy.PullRequest(false, "develop", true)
+	err := raidy.PullRequest(false, "develop", true, "")
 
 	require.Error(t, err, "expected an error when there is no pull request to duplicate")
 	assert.Contains(t, err.Error(), "error finding an existing pull request to duplicate")
@@ -650,7 +663,7 @@ func TestReal_MergeRequest(t *testing.T) {
 	out := output.NewMock()
 	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github.NewMock(), editor: out, cache: cache.NewMockAidyCache(), logger: log.Default()}
 
-	err := raidy.MergeRequest(false, "", false)
+	err := raidy.MergeRequest(false, "", false, "")
 
 	require.NoError(t, err, "expected no error when creating merge request")
 	result := out.Last()
@@ -662,7 +675,7 @@ func TestReal_MergeRequest_Target(t *testing.T) {
 	out := output.NewMock()
 	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github.NewMock(), editor: out, cache: cache.NewMockAidyCache(), logger: log.Default()}
 
-	err := raidy.MergeRequest(false, "develop", false)
+	err := raidy.MergeRequest(false, "develop", false, "")
 
 	require.NoError(t, err, "expected no error when creating merge request with target branch")
 	result := out.Last()
@@ -673,7 +686,7 @@ func TestReal_MergeRequest_Fixes(t *testing.T) {
 	out := output.NewMock()
 	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github.NewMock(), editor: out, cache: cache.NewMockAidyCache(), logger: log.NewMock()}
 
-	err := raidy.MergeRequest(true, "", false)
+	err := raidy.MergeRequest(true, "", false, "")
 
 	require.NoError(t, err, "expected no error when creating merge request with fixes")
 	result := out.Last()
@@ -685,21 +698,34 @@ func TestReal_MergeRequest_Duplicate(t *testing.T) {
 	out := output.NewMock()
 	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github.NewMock(), gitlab: gitlab.NewMock(), editor: out, cache: cache.NewMockAidyCache(), logger: log.Default()}
 
-	err := raidy.MergeRequest(false, "develop", true)
+	err := raidy.MergeRequest(false, "develop", true, "")
 
 	require.NoError(t, err, "expected no error when duplicating a merge request")
 	result := out.Last()
 	assert.Contains(t, result, "glab mr create", "Expected output to contain 'glab mr create'")
 	assert.Contains(t, result, "--target-branch develop", "Expected output to contain target branch")
-	assert.Contains(t, result, "mock title for branch", "Expected output to reuse the existing merge request title")
-	assert.Contains(t, result, "mock body for branch", "Expected output to reuse the existing merge request body")
+	assert.Contains(t, result, "mock title for branch '41_working_branch'", "Expected output to reuse the current branch's merge request title")
+	assert.Contains(t, result, "mock body for branch '41_working_branch'", "Expected output to reuse the current branch's merge request body")
+}
+
+func TestReal_MergeRequest_Duplicate_Source(t *testing.T) {
+	out := output.NewMock()
+	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github.NewMock(), gitlab: gitlab.NewMock(), editor: out, cache: cache.NewMockAidyCache(), logger: log.Default()}
+
+	err := raidy.MergeRequest(false, "develop", true, "feature-x")
+
+	require.NoError(t, err, "expected no error when duplicating a merge request from a given source branch")
+	result := out.Last()
+	assert.Contains(t, result, "--target-branch develop", "Expected output to contain target branch")
+	assert.Contains(t, result, "mock title for branch 'feature-x'", "Expected output to reuse the source branch's merge request title")
+	assert.Contains(t, result, "mock body for branch 'feature-x'", "Expected output to reuse the source branch's merge request body")
 }
 
 func TestReal_MergeRequest_Duplicate_NoTarget(t *testing.T) {
 	out := output.NewMock()
 	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github.NewMock(), gitlab: gitlab.NewMock(), editor: out, cache: cache.NewMockAidyCache(), logger: log.Default()}
 
-	err := raidy.MergeRequest(false, "", true)
+	err := raidy.MergeRequest(false, "", true, "")
 
 	require.Error(t, err, "expected an error when duplicating a merge request without a target branch")
 	assert.Contains(t, err.Error(), "--duplicate requires --target")
@@ -711,7 +737,7 @@ func TestReal_MergeRequest_Duplicate_NotFound(t *testing.T) {
 	out := output.NewMock()
 	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github.NewMock(), gitlab: gl, editor: out, cache: cache.NewMockAidyCache(), logger: log.Default()}
 
-	err := raidy.MergeRequest(false, "develop", true)
+	err := raidy.MergeRequest(false, "develop", true, "")
 
 	require.Error(t, err, "expected an error when there is no merge request to duplicate")
 	assert.Contains(t, err.Error(), "error finding an existing merge request to duplicate")


### PR DESCRIPTION
Add `--source` flag to `--duplicate` for PR/MR commands, allowing users to specify a source branch other than the currently checked-out one. When omitted, behavior defaults to the current branch as before.

Fixes #301