### PR TITLE
feat(#303): save release notes to platform-specific directories

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -23,11 +23,20 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: stable
+      - name: Resolve release notes file
+        id: notes
+        run: |
+          file=".github/release-notes/${{ github.ref_name }}.md"
+          if [ -f "$file" ]; then
+            echo "flag=--release-notes=$file" >> "$GITHUB_OUTPUT"
+          else
+            echo "flag=" >> "$GITHUB_OUTPUT"
+          fi
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: "~> v2"
-          args: release --clean
+          args: release --clean ${{ steps.notes.outputs.flag }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage.out
 # Added by goreleaser init:
 dist/
 .aidy/
+app

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,7 +28,6 @@ archives:
         formats: [zip]
 
 release:
-  header: "{{ .TagContents }}"
   github:
     owner: volodya-lombrozo
     name: aidy

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -6,15 +6,17 @@ import (
 
 func newReleaseCmd(ctx *Context) *cobra.Command {
 	var repo string
+	var notes bool
 	command := &cobra.Command{
 		Use:     "release [increment]",
 		Aliases: []string{"r"},
 		Args:    cobra.ExactArgs(1),
 		Short:   "Create a release based on a semver increment",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return ctx.Assistant.Release(args[0], repo)
+			return ctx.Assistant.Release(args[0], repo, notes)
 		},
 	}
 	command.Flags().StringVarP(&repo, "repo", "r", "", "repository where to look for tags")
+	command.Flags().BoolVarP(&notes, "notes", "n", false, "Save generated release notes as a markdown file named after the tag")
 	return command
 }

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -17,6 +17,6 @@ func newReleaseCmd(ctx *Context) *cobra.Command {
 		},
 	}
 	command.Flags().StringVarP(&repo, "repo", "r", "", "repository where to look for tags")
-	command.Flags().BoolVarP(&notes, "notes", "n", false, "Save generated release notes as a markdown file named after the tag")
+	command.Flags().BoolVar(&notes, "notes", false, "Save generated release notes as a markdown file named after the tag")
 	return command
 }

--- a/cmd/release_test.go
+++ b/cmd/release_test.go
@@ -25,10 +25,10 @@ func TestRelease_Execution(t *testing.T) {
 	mock := aidy.NewMock()
 	ctx := &Context{Assistant: mock}
 	command := newReleaseCmd(ctx)
-	command.SetArgs([]string{"minor", "--repo", "test-repo"})
+	command.SetArgs([]string{"minor", "--repo", "test-repo", "--notes"})
 
 	err := command.Execute()
 
 	require.NoError(t, err, "no error expected")
-	assert.Contains(t, mock.Logs(), "Release called with interval: minor, repo: test-repo")
+	assert.Contains(t, mock.Logs(), "Release called with interval: minor, repo: test-repo, notes: true")
 }

--- a/internal/aidy/aidy.go
+++ b/internal/aidy/aidy.go
@@ -1,7 +1,7 @@
 package aidy
 
 type Aidy interface {
-	Release(interval, repo string) error
+	Release(interval, repo string, notes bool) error
 	PrintConfig() error
 	Commit(issue bool) error
 	Squash(issue bool)

--- a/internal/aidy/mock.go
+++ b/internal/aidy/mock.go
@@ -13,8 +13,8 @@ func NewMock() *Mock {
 	return &Mock{logs: []string{}}
 }
 
-func (m *Mock) Release(interval string, repo string) error {
-	m.logs = append(m.logs, fmt.Sprintf("Release called with interval: %s, repo: %s", interval, repo))
+func (m *Mock) Release(interval string, repo string, notes bool) error {
+	m.logs = append(m.logs, fmt.Sprintf("Release called with interval: %s, repo: %s, notes: %t", interval, repo, notes))
 	return nil
 }
 
@@ -80,19 +80,21 @@ func NewFailingMock() *FailingMock {
 	return &FailingMock{}
 }
 
-func (f *FailingMock) Release(interval string, repo string) error   { return errors.New("error") }
-func (f *FailingMock) PrintConfig() error                           { return errors.New("error") }
-func (f *FailingMock) Commit(issue bool) error                      { return errors.New("error") }
-func (f *FailingMock) Squash(issue bool)                            {}
+func (f *FailingMock) Release(interval string, repo string, notes bool) error {
+	return errors.New("error")
+}
+func (f *FailingMock) PrintConfig() error      { return errors.New("error") }
+func (f *FailingMock) Commit(issue bool) error { return errors.New("error") }
+func (f *FailingMock) Squash(issue bool)       {}
 func (f *FailingMock) PullRequest(fixes bool, target string, duplicate bool, source string) error {
 	return errors.New("error")
 }
 func (f *FailingMock) MergeRequest(fixes bool, target string, duplicate bool, source string) error {
 	return errors.New("error")
 }
-func (f *FailingMock) Issue(task string) error                      { return errors.New("error") }
-func (f *FailingMock) Heal() error                                  { return errors.New("error") }
-func (f *FailingMock) Append()                                      {}
-func (f *FailingMock) Clean()                                       {}
-func (f *FailingMock) Diff() error                                  { return errors.New("error") }
-func (f *FailingMock) StartIssue(number string) error               { return errors.New("error") }
+func (f *FailingMock) Issue(task string) error        { return errors.New("error") }
+func (f *FailingMock) Heal() error                    { return errors.New("error") }
+func (f *FailingMock) Append()                        {}
+func (f *FailingMock) Clean()                         {}
+func (f *FailingMock) Diff() error                    { return errors.New("error") }
+func (f *FailingMock) StartIssue(number string) error { return errors.New("error") }

--- a/internal/aidy/mock_test.go
+++ b/internal/aidy/mock_test.go
@@ -9,9 +9,9 @@ import (
 
 func TestMockAidy_Release(t *testing.T) {
 	aidy := NewMock()
-	err := aidy.Release("daily", "repo-name")
+	err := aidy.Release("daily", "repo-name", true)
 	assert.NoError(t, err)
-	assert.Contains(t, aidy.Logs(), "Release called with interval: daily, repo: repo-name")
+	assert.Contains(t, aidy.Logs(), "Release called with interval: daily, repo: repo-name, notes: true")
 }
 
 func TestMockAidy_PrintConfig(t *testing.T) {

--- a/internal/aidy/real.go
+++ b/internal/aidy/real.go
@@ -597,8 +597,66 @@ func (r *real) Release(interval string, repo string) error {
 		}
 		r.logger.Info("no tags found, creating the first release with version '%s'", updated)
 	}
+	if err := r.save(updated, notes); err != nil {
+		return fmt.Errorf("failed to save release notes: '%v'", err)
+	}
 	command := fmt.Sprintf("git tag --cleanup=verbatim -a \"%s\" -m \"%s\" ", updated, notes)
 	return r.editor.Print(command)
+}
+
+// save writes the generated release notes to a markdown file under
+// .github/release-notes/ and/or .gitlab/release-notes/, depending on which
+// hosts the git remotes point to.
+func (r *real) save(version string, notes string) error {
+	root, err := r.git.Root()
+	if err != nil {
+		return fmt.Errorf("failed to get repository root: %w", err)
+	}
+	remotes, err := r.git.Remotes()
+	if err != nil {
+		return fmt.Errorf("failed to get git remotes: %w", err)
+	}
+	targets, err := dirs(remotes)
+	if err != nil {
+		return err
+	}
+	for _, dir := range targets {
+		path := filepath.Join(root, dir, version+".md")
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			return fmt.Errorf("failed to create release notes directory '%s': %w", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte(notes), 0644); err != nil {
+			return fmt.Errorf("failed to write release notes file '%s': %w", path, err)
+		}
+		r.logger.Info("saved release notes to '%s'", path)
+	}
+	return nil
+}
+
+// dirs determines where release notes should be saved based on the hosts of
+// the given git remotes. It errors when no known host is detected, since
+// silently guessing a location could put notes where nobody looks.
+func dirs(remotes []string) ([]string, error) {
+	var found []string
+	if has(remotes, "github.com") {
+		found = append(found, filepath.Join(".github", "release-notes"))
+	}
+	if has(remotes, "gitlab.com") {
+		found = append(found, filepath.Join(".gitlab", "release-notes"))
+	}
+	if len(found) == 0 {
+		return nil, fmt.Errorf("no known git host (github.com or gitlab.com) found in remotes: %v", remotes)
+	}
+	return found, nil
+}
+
+func has(remotes []string, host string) bool {
+	for _, remote := range remotes {
+		if strings.Contains(remote, host) {
+			return true
+		}
+	}
+	return false
 }
 
 func keys(m map[string]string) []string {

--- a/internal/aidy/real.go
+++ b/internal/aidy/real.go
@@ -545,7 +545,7 @@ func branchName(number string, suggested string) string {
 	return fmt.Sprintf("%s-%s", number, suggested)
 }
 
-func (r *real) Release(interval string, repo string) error {
+func (r *real) Release(interval string, repo string, saveNotes bool) error {
 	tags, err := r.git.Tags(repo)
 	if err != nil {
 		return fmt.Errorf("failed to get tags: '%v'", err)
@@ -597,8 +597,10 @@ func (r *real) Release(interval string, repo string) error {
 		}
 		r.logger.Info("no tags found, creating the first release with version '%s'", updated)
 	}
-	if err := r.save(updated, notes); err != nil {
-		return fmt.Errorf("failed to save release notes: '%v'", err)
+	if saveNotes {
+		if err := r.save(updated, notes); err != nil {
+			return fmt.Errorf("failed to save release notes: '%v'", err)
+		}
 	}
 	command := fmt.Sprintf("git tag --cleanup=verbatim -a \"%s\" -m \"%s\" ", updated, notes)
 	return r.editor.Print(command)

--- a/internal/aidy/real_test.go
+++ b/internal/aidy/real_test.go
@@ -903,6 +903,67 @@ func TestReal_Release_NotesGenerationError(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to generate release notes", "expected error message about release notes generation")
 }
 
+func TestReal_Release_SaveNotes_GitHub(t *testing.T) {
+	tmp := t.TempDir()
+	shell := executor.NewMock()
+	shell.Output = "https://github.com/volodya-lombrozo/aidy.git"
+	mgit := git.NewMockWithDirAndShell(tmp, shell)
+	out := output.NewMock()
+	raidy := &real{git: mgit, ai: ai.NewMockAI(), editor: out, logger: log.NewMock()}
+
+	err := raidy.Release("minor", "origin", true)
+
+	require.NoError(t, err, "expected no error during release")
+	notes, rerr := os.ReadFile(filepath.Join(tmp, ".github", "release-notes", "v2.1.0.md"))
+	require.NoError(t, rerr, "expected release notes file to be written under .github")
+	assert.Contains(t, string(notes), "Mock Release Notes", "expected release notes file to contain generated notes")
+}
+
+func TestReal_Release_SaveNotes_GitLab(t *testing.T) {
+	tmp := t.TempDir()
+	shell := executor.NewMock()
+	shell.Output = "https://gitlab.com/volodya-lombrozo/aidy.git"
+	mgit := git.NewMockWithDirAndShell(tmp, shell)
+	out := output.NewMock()
+	raidy := &real{git: mgit, ai: ai.NewMockAI(), editor: out, logger: log.NewMock()}
+
+	err := raidy.Release("minor", "origin", true)
+
+	require.NoError(t, err, "expected no error during release")
+	notes, rerr := os.ReadFile(filepath.Join(tmp, ".gitlab", "release-notes", "v2.1.0.md"))
+	require.NoError(t, rerr, "expected release notes file to be written under .gitlab")
+	assert.Contains(t, string(notes), "Mock Release Notes", "expected release notes file to contain generated notes")
+}
+
+func TestReal_Release_SaveNotes_UnknownHost(t *testing.T) {
+	tmp := t.TempDir()
+	shell := executor.NewMock()
+	shell.Output = "https://bitbucket.org/volodya-lombrozo/aidy.git"
+	mgit := git.NewMockWithDirAndShell(tmp, shell)
+	out := output.NewMock()
+	raidy := &real{git: mgit, ai: ai.NewMockAI(), editor: out, logger: log.NewMock()}
+
+	err := raidy.Release("minor", "origin", true)
+
+	assert.Error(t, err, "expected error when the git host can't be determined")
+	assert.Contains(t, err.Error(), "no known git host", "expected error to mention the unknown host")
+}
+
+func TestReal_Release_SkipsSavingNotesByDefault(t *testing.T) {
+	tmp := t.TempDir()
+	shell := executor.NewMock()
+	shell.Output = "https://bitbucket.org/volodya-lombrozo/aidy.git"
+	mgit := git.NewMockWithDirAndShell(tmp, shell)
+	out := output.NewMock()
+	raidy := &real{git: mgit, ai: ai.NewMockAI(), editor: out, logger: log.NewMock()}
+
+	err := raidy.Release("minor", "origin", false)
+
+	require.NoError(t, err, "expected no error when notes saving is disabled, even with an unknown host")
+	_, rerr := os.ReadFile(filepath.Join(tmp, ".github", "release-notes", "v2.1.0.md"))
+	assert.True(t, os.IsNotExist(rerr), "expected no release notes file to be written when --notes is not set")
+}
+
 func TestHealQoutes(t *testing.T) {
 	message := healQuotes("\"with \" qoutes\"")
 	assert.Equal(t, "\"with \" qoutes\"", message)

--- a/internal/aidy/real_test.go
+++ b/internal/aidy/real_test.go
@@ -815,7 +815,7 @@ func TestReal_Release_Success(t *testing.T) {
 	out := output.NewMock()
 	raidy := &real{git: mgit, ai: nobrain, editor: out, logger: log.NewMock()}
 
-	err := raidy.Release("minor", "origin")
+	err := raidy.Release("minor", "origin", false)
 	assert.NoError(t, err, "expected no error during release")
 	expected := "git tag --cleanup=verbatim -a \"v2.1.0\" -m \""
 	assert.Contains(t, out.Last(), expected, "expected release command to be generated")
@@ -829,7 +829,7 @@ func TestReal_Release_NoTags_Patch(t *testing.T) {
 
 	raidy := &real{git: mockGit, ai: ai.NewMockAI(), editor: output, logger: log.NewMock()}
 
-	err := raidy.Release("patch", "origin")
+	err := raidy.Release("patch", "origin", false)
 
 	require.NoError(t, err, "expected no error when releasing with no tags")
 	expected := "git tag --cleanup=verbatim -a \"v0.0.1\" -m \""
@@ -844,7 +844,7 @@ func TestReal_Release_NoTags_Minor(t *testing.T) {
 
 	raidy := &real{git: mockGit, ai: ai.NewMockAI(), editor: output, logger: log.NewMock()}
 
-	err := raidy.Release("minor", "origin")
+	err := raidy.Release("minor", "origin", false)
 
 	require.NoError(t, err, "expected no error when releasing with no tags")
 	expected := "git tag --cleanup=verbatim -a \"v0.1.0\" -m \""
@@ -859,7 +859,7 @@ func TestReal_Release_NoTags_Major(t *testing.T) {
 
 	raidy := &real{git: mockGit, ai: ai.NewMockAI(), editor: output, logger: log.NewMock()}
 
-	err := raidy.Release("major", "origin")
+	err := raidy.Release("major", "origin", false)
 
 	require.NoError(t, err, "expected no error when releasing with no tags")
 	expected := "git tag --cleanup=verbatim -a \"v1.0.0\" -m \""
@@ -872,7 +872,7 @@ func TestReal_ReleaseUnknownInterval(t *testing.T) {
 	out := output.NewMock()
 	raidy := &real{git: mockGit, ai: mockAI, editor: out, logger: log.NewMock()}
 
-	err := raidy.Release("", "origin")
+	err := raidy.Release("", "origin", false)
 
 	assert.EqualError(t, err, "failed to update version: 'unknown version step: '''", "expected error when no tags are present")
 }
@@ -885,7 +885,7 @@ func TestReal_Release_TagFetchError(t *testing.T) {
 	out := output.NewMock()
 	raidy := &real{git: mgit, ai: nobrain, editor: out, logger: log.NewMock()}
 
-	err := raidy.Release("patch", "origin")
+	err := raidy.Release("patch", "origin", false)
 
 	assert.Error(t, err, "expected error when fetching tags fails")
 	assert.Contains(t, err.Error(), "failed to get tags", "expected error message about fetching tags")
@@ -897,7 +897,7 @@ func TestReal_Release_NotesGenerationError(t *testing.T) {
 	out := output.NewMock()
 	raidy := &real{git: mgit, ai: nobrain, editor: out, logger: log.NewMock()}
 
-	err := raidy.Release("major", "origin")
+	err := raidy.Release("major", "origin", false)
 
 	assert.Error(t, err, "expected error when generating release notes fails")
 	assert.Contains(t, err.Error(), "failed to generate release notes", "expected error message about release notes generation")

--- a/internal/git/mock.go
+++ b/internal/git/mock.go
@@ -27,6 +27,10 @@ func NewMockWithShell(shell executor.Executor) Git {
 	return &mock{dir: "/dev/null", shell: shell, err: nil, log: log.NewMock()}
 }
 
+func NewMockWithDirAndShell(dir string, shell executor.Executor) Git {
+	return &mock{dir: dir, shell: shell, err: nil, log: log.NewMock()}
+}
+
 func NewMockWithError(err error) Git {
 	return &mock{dir: "/dev/null", shell: executor.NewMock(), err: err, log: log.NewMock()}
 }


### PR DESCRIPTION
Implement persistent storage of generated release notes to repository directories based on git host. Release notes are now saved to `.github/release-notes/<version>.md` for GitHub repos and `.gitlab/release-notes/<version>.md` for GitLab repos when the `--notes` flag is passed to `aidy release`.

Fixes #303