### PR TITLE
feat(#303): save and review release notes before committing

### DIFF
--- a/internal/aidy/real.go
+++ b/internal/aidy/real.go
@@ -1,6 +1,7 @@
 package aidy
 
 import (
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"os"
@@ -23,16 +24,17 @@ import (
 )
 
 type real struct {
-	git     git.Git
-	github  github.Github
-	gitlab  gitlab.Gitlab
-	ai      ai.AI
-	editor  output.Output
-	config  config.Config
-	cache   cache.AidyCache
-	printer output.Output
-	logger  log.Logger
-	in      *os.File
+	git        git.Git
+	github     github.Github
+	gitlab     gitlab.Gitlab
+	ai         ai.AI
+	editor     output.Output
+	config     config.Config
+	cache      cache.AidyCache
+	printer    output.Output
+	texteditor output.TextEditor
+	logger     log.Logger
+	in         *os.File
 }
 
 // Create a real aidy instance
@@ -52,6 +54,7 @@ func NewAidy(summary bool, aider bool, ailess bool, silent bool, debug bool, lan
 	shell := executor.NewReal()
 	aidy.editor = output.NewEditor(shell)
 	aidy.printer = output.NewPrinter()
+	aidy.texteditor = output.NewTextEditor(shell)
 	var err error
 	if aidy.git, err = git.NewGit(shell); err != nil {
 		aidy.logger.Error("failed to initialize git: %v", err)
@@ -598,6 +601,15 @@ func (r *real) Release(interval string, repo string, saveNotes bool) error {
 		r.logger.Info("no tags found, creating the first release with version '%s'", updated)
 	}
 	if saveNotes {
+		reviewed, err := r.texteditor.Edit(notes)
+		if err != nil {
+			if errors.Is(err, output.ErrCanceled) {
+				r.logger.Info("release canceled")
+				return nil
+			}
+			return fmt.Errorf("failed to review release notes: '%v'", err)
+		}
+		notes = reviewed
 		if err := r.save(updated, notes); err != nil {
 			return fmt.Errorf("failed to save release notes: '%v'", err)
 		}

--- a/internal/aidy/real.go
+++ b/internal/aidy/real.go
@@ -631,7 +631,15 @@ func (r *real) save(version string, notes string) error {
 			return fmt.Errorf("failed to write release notes file '%s': %w", path, err)
 		}
 		r.logger.Info("saved release notes to '%s'", path)
+		if _, err := r.git.Run("add", path); err != nil {
+			return fmt.Errorf("error adding '%s': %v", path, err)
+		}
 	}
+	message := fmt.Sprintf("chore: add release notes for %s", version)
+	if _, err := r.git.Run("commit", "-m", message); err != nil {
+		return fmt.Errorf("error committing release notes: %v", err)
+	}
+	r.logger.Info("commit was created with message: '%s'", message)
 	return nil
 }
 

--- a/internal/aidy/real_test.go
+++ b/internal/aidy/real_test.go
@@ -914,9 +914,13 @@ func TestReal_Release_SaveNotes_GitHub(t *testing.T) {
 	err := raidy.Release("minor", "origin", true)
 
 	require.NoError(t, err, "expected no error during release")
-	notes, rerr := os.ReadFile(filepath.Join(tmp, ".github", "release-notes", "v2.1.0.md"))
+	path := filepath.Join(tmp, ".github", "release-notes", "v2.1.0.md")
+	notes, rerr := os.ReadFile(path)
 	require.NoError(t, rerr, "expected release notes file to be written under .github")
 	assert.Contains(t, string(notes), "Mock Release Notes", "expected release notes file to contain generated notes")
+	commands := strings.Join(shell.Commands, "\n")
+	assert.Contains(t, commands, "git add "+path, "expected release notes file to be staged")
+	assert.Contains(t, commands, "git commit -m chore: add release notes for v2.1.0", "expected release notes to be committed")
 }
 
 func TestReal_Release_SaveNotes_GitLab(t *testing.T) {

--- a/internal/aidy/real_test.go
+++ b/internal/aidy/real_test.go
@@ -962,6 +962,21 @@ func TestReal_Release_SaveNotes_Canceled(t *testing.T) {
 	assert.NotContains(t, out.Captured(), "git tag", "expected no tag command to be generated when canceled")
 }
 
+func TestReal_Release_SaveNotes_ReviewError(t *testing.T) {
+	tmp := t.TempDir()
+	shell := executor.NewMock()
+	shell.Output = "https://github.com/volodya-lombrozo/aidy.git"
+	mgit := git.NewMockWithDirAndShell(tmp, shell)
+	out := output.NewMock()
+	out.EditErr = fmt.Errorf("review failed")
+	raidy := &real{git: mgit, ai: ai.NewMockAI(), editor: out, texteditor: out, logger: log.NewMock()}
+
+	err := raidy.Release("minor", "origin", true)
+
+	assert.Error(t, err, "expected an error when reviewing release notes fails")
+	assert.Contains(t, err.Error(), "failed to review release notes", "expected error message about reviewing release notes")
+}
+
 func TestReal_Release_SaveNotes_GitLab(t *testing.T) {
 	tmp := t.TempDir()
 	shell := executor.NewMock()

--- a/internal/aidy/real_test.go
+++ b/internal/aidy/real_test.go
@@ -909,7 +909,7 @@ func TestReal_Release_SaveNotes_GitHub(t *testing.T) {
 	shell.Output = "https://github.com/volodya-lombrozo/aidy.git"
 	mgit := git.NewMockWithDirAndShell(tmp, shell)
 	out := output.NewMock()
-	raidy := &real{git: mgit, ai: ai.NewMockAI(), editor: out, logger: log.NewMock()}
+	raidy := &real{git: mgit, ai: ai.NewMockAI(), editor: out, texteditor: out, logger: log.NewMock()}
 
 	err := raidy.Release("minor", "origin", true)
 
@@ -923,13 +923,52 @@ func TestReal_Release_SaveNotes_GitHub(t *testing.T) {
 	assert.Contains(t, commands, "git commit -m chore: add release notes for v2.1.0", "expected release notes to be committed")
 }
 
+func TestReal_Release_SaveNotes_UsesReviewedText(t *testing.T) {
+	tmp := t.TempDir()
+	shell := executor.NewMock()
+	shell.Output = "https://github.com/volodya-lombrozo/aidy.git"
+	mgit := git.NewMockWithDirAndShell(tmp, shell)
+	out := output.NewMock()
+	out.EditText = "edited release notes"
+	raidy := &real{git: mgit, ai: ai.NewMockAI(), editor: out, texteditor: out, logger: log.NewMock()}
+
+	err := raidy.Release("minor", "origin", true)
+
+	require.NoError(t, err, "expected no error during release")
+	path := filepath.Join(tmp, ".github", "release-notes", "v2.1.0.md")
+	notes, rerr := os.ReadFile(path)
+	require.NoError(t, rerr, "expected release notes file to be written")
+	assert.Equal(t, "edited release notes", string(notes), "expected the reviewed/edited text to be saved, not the original AI output")
+	assert.Contains(t, out.Last(), "-m \"edited release notes\"", "expected the tag message to use the reviewed text")
+}
+
+func TestReal_Release_SaveNotes_Canceled(t *testing.T) {
+	tmp := t.TempDir()
+	shell := executor.NewMock()
+	shell.Output = "https://github.com/volodya-lombrozo/aidy.git"
+	mgit := git.NewMockWithDirAndShell(tmp, shell)
+	out := output.NewMock()
+	out.EditErr = output.ErrCanceled
+	raidy := &real{git: mgit, ai: ai.NewMockAI(), editor: out, texteditor: out, logger: log.NewMock()}
+
+	err := raidy.Release("minor", "origin", true)
+
+	require.NoError(t, err, "expected no error when the notes review is canceled")
+	_, rerr := os.ReadFile(filepath.Join(tmp, ".github", "release-notes", "v2.1.0.md"))
+	assert.True(t, os.IsNotExist(rerr), "expected no release notes file to be written when canceled")
+	commands := strings.Join(shell.Commands, "\n")
+	assert.NotContains(t, commands, "git add", "expected no release notes file to be staged when canceled")
+	assert.NotContains(t, commands, "git commit", "expected no commit to be made when canceled")
+	assert.NotContains(t, out.Captured(), "git tag", "expected no tag command to be generated when canceled")
+}
+
 func TestReal_Release_SaveNotes_GitLab(t *testing.T) {
 	tmp := t.TempDir()
 	shell := executor.NewMock()
 	shell.Output = "https://gitlab.com/volodya-lombrozo/aidy.git"
 	mgit := git.NewMockWithDirAndShell(tmp, shell)
 	out := output.NewMock()
-	raidy := &real{git: mgit, ai: ai.NewMockAI(), editor: out, logger: log.NewMock()}
+	raidy := &real{git: mgit, ai: ai.NewMockAI(), editor: out, texteditor: out, logger: log.NewMock()}
 
 	err := raidy.Release("minor", "origin", true)
 
@@ -945,7 +984,7 @@ func TestReal_Release_SaveNotes_UnknownHost(t *testing.T) {
 	shell.Output = "https://bitbucket.org/volodya-lombrozo/aidy.git"
 	mgit := git.NewMockWithDirAndShell(tmp, shell)
 	out := output.NewMock()
-	raidy := &real{git: mgit, ai: ai.NewMockAI(), editor: out, logger: log.NewMock()}
+	raidy := &real{git: mgit, ai: ai.NewMockAI(), editor: out, texteditor: out, logger: log.NewMock()}
 
 	err := raidy.Release("minor", "origin", true)
 
@@ -959,7 +998,7 @@ func TestReal_Release_SkipsSavingNotesByDefault(t *testing.T) {
 	shell.Output = "https://bitbucket.org/volodya-lombrozo/aidy.git"
 	mgit := git.NewMockWithDirAndShell(tmp, shell)
 	out := output.NewMock()
-	raidy := &real{git: mgit, ai: ai.NewMockAI(), editor: out, logger: log.NewMock()}
+	raidy := &real{git: mgit, ai: ai.NewMockAI(), editor: out, texteditor: out, logger: log.NewMock()}
 
 	err := raidy.Release("minor", "origin", false)
 

--- a/internal/output/mock.go
+++ b/internal/output/mock.go
@@ -4,6 +4,8 @@ import "strings"
 
 type Mock struct {
 	captured []string
+	EditErr  error
+	EditText string
 }
 
 func NewMock() *Mock {
@@ -13,6 +15,17 @@ func NewMock() *Mock {
 func (m *Mock) Print(command string) error {
 	m.captured = append(m.captured, command)
 	return nil
+}
+
+func (m *Mock) Edit(text string) (string, error) {
+	m.captured = append(m.captured, text)
+	if m.EditErr != nil {
+		return "", m.EditErr
+	}
+	if m.EditText != "" {
+		return m.EditText, nil
+	}
+	return text, nil
 }
 
 func (m *Mock) Captured() string {

--- a/internal/output/mock_test.go
+++ b/internal/output/mock_test.go
@@ -27,3 +27,43 @@ func TestMockOutput_Panics_WhenNoCommands(t *testing.T) {
 	}()
 	mock.Last()
 }
+
+func TestMock_Captured(t *testing.T) {
+	mock := NewMock()
+	require.Equal(t, "", mock.Captured(), "expected empty string when nothing was captured")
+
+	_ = mock.Print("command1")
+	_ = mock.Print("command2")
+
+	require.Equal(t, "command1\ncommand2", mock.Captured(), "expected captured commands joined by newline")
+}
+
+func TestMock_Edit_DefaultAccepts(t *testing.T) {
+	mock := NewMock()
+
+	result, err := mock.Edit("some text")
+
+	require.NoError(t, err, "expected no error by default")
+	require.Equal(t, "some text", result, "expected the original text to be returned unchanged")
+	require.Equal(t, "some text", mock.Captured(), "expected the text to be recorded")
+}
+
+func TestMock_Edit_ReturnsConfiguredText(t *testing.T) {
+	mock := NewMock()
+	mock.EditText = "edited text"
+
+	result, err := mock.Edit("some text")
+
+	require.NoError(t, err, "expected no error")
+	require.Equal(t, "edited text", result, "expected the configured text to be returned")
+}
+
+func TestMock_Edit_ReturnsConfiguredError(t *testing.T) {
+	mock := NewMock()
+	mock.EditErr = ErrCanceled
+
+	result, err := mock.Edit("some text")
+
+	require.ErrorIs(t, err, ErrCanceled, "expected the configured error to be returned")
+	require.Equal(t, "", result, "expected no text to be returned on error")
+}

--- a/internal/output/texteditor.go
+++ b/internal/output/texteditor.go
@@ -1,0 +1,114 @@
+package output
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+
+	"github.com/volodya-lombrozo/aidy/internal/executor"
+	"github.com/volodya-lombrozo/aidy/internal/log"
+)
+
+var ErrCanceled = errors.New("canceled")
+
+type TextEditor interface {
+	Edit(text string) (string, error)
+}
+
+type textEditor struct {
+	external string
+	shell    executor.Executor
+	err      *os.File
+	in       *os.File
+	out      *os.File
+	log      log.Logger
+}
+
+func NewTextEditor(shell executor.Executor) *textEditor {
+	return &textEditor{
+		external: findEditor(runtime.GOOS),
+		shell:    shell,
+		err:      os.Stderr,
+		in:       os.Stdin,
+		out:      os.Stdout,
+		log:      log.Default(),
+	}
+}
+
+func (e *textEditor) Edit(text string) (string, error) {
+	e.printf("\n%s\n", text)
+	reader := bufio.NewReader(e.in)
+	for {
+		e.printf("%s", "[a]ccept, [e]dit, [c]ancel, [p]rint? ")
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			e.printfErr("%s: %v\n", "Error reading input", err)
+			return "", err
+		}
+		switch strings.ToLower(strings.TrimSpace(line)) {
+		case "a":
+			return text, nil
+		case "e":
+			updated, err := e.edit(text)
+			if err != nil {
+				return "", fmt.Errorf("failed to edit text: %w", err)
+			}
+			if updated == "" {
+				return "", ErrCanceled
+			}
+			text = updated
+			e.printf("\nupdated:\n%s\n", text)
+		case "c":
+			e.printf("%s\n", "canceled.")
+			return "", ErrCanceled
+		case "p":
+			e.printf("%s\n", text)
+			return "", ErrCanceled
+		default:
+			e.printfErr("%s\n", "please type a, e, c, or p and press enter.")
+		}
+	}
+}
+
+func (e *textEditor) edit(input string) (string, error) {
+	tmp, err := os.CreateTemp("", "aidy-edittext-*.txt")
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if err := os.Remove(tmp.Name()); err != nil {
+			e.log.Error("failed to remove temp file '%s': %v", tmp.Name(), err)
+		}
+	}()
+	if _, err := tmp.WriteString(input); err != nil {
+		panic(err)
+	}
+	if err := tmp.Close(); err != nil {
+		e.log.Error("failed to close temp file '%s': %v", tmp.Name(), err)
+	}
+	parts := strings.Fields(e.external)
+	args := append(parts[1:], tmp.Name())
+	if _, err := e.shell.RunInteractively(parts[0], args...); err != nil {
+		return "", fmt.Errorf("failed to run command '%s %s': %w", e.external, tmp.Name(), err)
+	}
+	edited, err := os.ReadFile(tmp.Name())
+	if err != nil {
+		return "", fmt.Errorf("failed to read edited file '%s': %w", tmp.Name(), err)
+	}
+	return string(edited), nil
+}
+
+func (e *textEditor) printf(format string, args ...any) {
+	if _, err := fmt.Fprintf(e.out, format, args...); err != nil {
+		panic(err)
+	}
+}
+
+func (e *textEditor) printfErr(format string, args ...any) {
+	if _, err := fmt.Fprintf(e.err, format, args...); err != nil {
+		panic(err)
+	}
+}

--- a/internal/output/texteditor_test.go
+++ b/internal/output/texteditor_test.go
@@ -1,0 +1,122 @@
+package output
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/volodya-lombrozo/aidy/internal/executor"
+)
+
+func TestTextEditor_Edit_AcceptOption(t *testing.T) {
+	r, w, _ := os.Pipe()
+	shell := executor.NewMock()
+	editor := NewTextEditor(shell)
+	editor.in = r
+	_, err := io.WriteString(w, "a\n")
+	require.NoError(t, err, "failed to write to pipe")
+	err = w.Close()
+	require.NoError(t, err, "failed to close write pipe")
+	text := "release notes text"
+
+	result, err := editor.Edit(text)
+
+	require.NoError(t, err, "Edit should not return an error")
+	assert.Equal(t, text, result, "expected the original text to be returned unchanged")
+	assert.Len(t, shell.Commands, 0, "expected no external editor to be run")
+}
+
+func TestTextEditor_Edit_CancelOption(t *testing.T) {
+	input_r, input_w, _ := os.Pipe()
+	output_r, output_w, _ := os.Pipe()
+	shell := executor.NewMock()
+	editor := NewTextEditor(shell)
+	editor.in = input_r
+	editor.out = output_w
+	_, err := io.WriteString(input_w, "c\n")
+	require.NoError(t, err, "failed to write to pipe")
+	err = input_w.Close()
+	require.NoError(t, err, "failed to close write pipe")
+	text := "release notes text"
+
+	result, err := editor.Edit(text)
+
+	assert.ErrorIs(t, err, ErrCanceled, "expected a canceled error")
+	assert.Empty(t, result, "expected no text to be returned when canceled")
+	err = output_w.Close()
+	require.NoError(t, err, "failed to close output pipe")
+	output, err := io.ReadAll(output_r)
+	require.NoError(t, err, "failed to read from output")
+	assert.Contains(t, string(output), "canceled", "expected cancel message in output")
+}
+
+func TestTextEditor_Edit_PrintOption(t *testing.T) {
+	input_r, input_w, _ := os.Pipe()
+	output_r, output_w, _ := os.Pipe()
+	shell := executor.NewMock()
+	editor := NewTextEditor(shell)
+	editor.in = input_r
+	editor.out = output_w
+	_, err := io.WriteString(input_w, "p\n")
+	require.NoError(t, err, "failed to write to pipe")
+	err = input_w.Close()
+	require.NoError(t, err, "failed to close write pipe")
+	text := "release notes text"
+
+	result, err := editor.Edit(text)
+
+	assert.ErrorIs(t, err, ErrCanceled, "expected a canceled error")
+	assert.Empty(t, result, "expected no text to be returned after printing")
+	err = output_w.Close()
+	require.NoError(t, err, "failed to close output pipe")
+	output, err := io.ReadAll(output_r)
+	require.NoError(t, err, "failed to read from output")
+	assert.Contains(t, string(output), text, "expected text in output")
+}
+
+func TestTextEditor_Edit_EditOption(t *testing.T) {
+	input_r, input_w, _ := os.Pipe()
+	output_r, output_w, _ := os.Pipe()
+	shell := executor.NewMock()
+	editor := NewTextEditor(shell)
+	editor.in = input_r
+	editor.out = output_w
+	_, err := io.WriteString(input_w, "e\na\n")
+	require.NoError(t, err, "failed to write to pipe")
+	err = input_w.Close()
+	require.NoError(t, err, "failed to close write pipe")
+	text := "release notes text"
+
+	result, err := editor.Edit(text)
+
+	require.NoError(t, err, "Edit should not return an error")
+	assert.Equal(t, text, result, "expected the unmodified temp file content to be returned")
+	assert.Len(t, shell.Commands, 1, "expected the external editor to be run once")
+	err = output_w.Close()
+	require.NoError(t, err, "failed to close output pipe")
+	output, err := io.ReadAll(output_r)
+	require.NoError(t, err, "failed to read from output")
+	assert.Contains(t, string(output), "updated", "expected updated text label in output")
+}
+
+func TestTextEditor_Edit_EditOption_FailsWithError(t *testing.T) {
+	r, w, _ := os.Pipe()
+	shell := executor.NewMock()
+	shell.Err = fmt.Errorf("simulated error")
+	editor := NewTextEditor(shell)
+	editor.in = r
+	_, err := io.WriteString(w, "e\n")
+	require.NoError(t, err, "failed to write to pipe")
+	err = w.Close()
+	require.NoError(t, err, "failed to close write pipe")
+	text := "release notes text"
+
+	_, err = editor.Edit(text)
+
+	assert.Error(t, err, "expected an error when the external editor fails")
+	assert.Contains(t, err.Error(), "simulated error", "expected error message to match")
+	assert.Contains(t, err.Error(), "failed to edit text", "expected error to mention text editing failure")
+}

--- a/internal/output/texteditor_test.go
+++ b/internal/output/texteditor_test.go
@@ -120,3 +120,46 @@ func TestTextEditor_Edit_EditOption_FailsWithError(t *testing.T) {
 	assert.Contains(t, err.Error(), "simulated error", "expected error message to match")
 	assert.Contains(t, err.Error(), "failed to edit text", "expected error to mention text editing failure")
 }
+
+func TestTextEditor_Edit_InvalidOption(t *testing.T) {
+	input_r, input_w, _ := os.Pipe()
+	err_r, err_w, _ := os.Pipe()
+	shell := executor.NewMock()
+	editor := NewTextEditor(shell)
+	editor.in = input_r
+	editor.err = err_w
+	_, err := io.WriteString(input_w, "x\na\n")
+	require.NoError(t, err, "failed to write to pipe")
+	err = input_w.Close()
+	require.NoError(t, err, "failed to close write pipe")
+	text := "release notes text"
+
+	result, err := editor.Edit(text)
+
+	require.NoError(t, err, "Edit should not return an error once a valid option is given")
+	assert.Equal(t, text, result, "expected the original text to be returned unchanged")
+	err = err_w.Close()
+	require.NoError(t, err, "failed to close error pipe")
+	output, err := io.ReadAll(err_r)
+	require.NoError(t, err, "failed to read from error output")
+	assert.Contains(t, string(output), "please type a, e, c, or p", "expected a hint about valid options")
+}
+
+func TestTextEditor_Edit_ReadError(t *testing.T) {
+	input_r, input_w, _ := os.Pipe()
+	err_r, err_w, _ := os.Pipe()
+	shell := executor.NewMock()
+	editor := NewTextEditor(shell)
+	editor.in = input_r
+	editor.err = err_w
+	require.NoError(t, input_w.Close(), "failed to close write pipe")
+	text := "release notes text"
+
+	_, err := editor.Edit(text)
+
+	assert.Error(t, err, "expected an error when reading input fails")
+	require.NoError(t, err_w.Close(), "failed to close error pipe")
+	output, rerr := io.ReadAll(err_r)
+	require.NoError(t, rerr, "failed to read from error output")
+	assert.Contains(t, string(output), "Error reading input", "expected an input-reading error message")
+}


### PR DESCRIPTION
This PR adds the ability to save generated release notes to persistent files in the repository when running `aidy release`. Users can now review and edit the notes before they are committed, with support for both GitHub (`.github/release-notes/<version>.md`) and GitLab (`.gitlab/release-notes/<version>.md`) repositories.

Fixes #303