### PR TITLE
fix(#307): handle multiple merge requests for a branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage.out
 dist/
 .aidy/
 app
+.claude/

--- a/internal/gitlab/real.go
+++ b/internal/gitlab/real.go
@@ -23,17 +23,21 @@ func NewGitlab(shell executor.Executor) *real {
 }
 
 func (r *real) MergeRequestByBranch(branch string) (string, string, error) {
-	out, err := r.shell.RunCommand("glab", "mr", "view", branch, "--output", "json")
+	out, err := r.shell.RunCommand("glab", "mr", "list", "--source-branch", branch, "--output", "json")
 	if err != nil {
-		return "", "", fmt.Errorf("error fetching merge request for branch '%s': %w", branch, err)
+		return "", "", fmt.Errorf("error fetching merge requests for branch '%s': %w", branch, err)
 	}
-	var mr mergeRequest
-	if err := json.Unmarshal([]byte(out), &mr); err != nil {
+	var mrs []mergeRequest
+	if err := json.Unmarshal([]byte(out), &mrs); err != nil {
 		return "", "", fmt.Errorf("error parsing merge request json for branch '%s': %w", branch, err)
 	}
-	if mr.Title == "" {
+	if len(mrs) == 0 {
 		return "", "", fmt.Errorf("no open merge request found for branch '%s'", branch)
 	}
+	if len(mrs) > 1 {
+		r.log.Warn("found %d open merge requests for branch '%s', using the first one: '%s'", len(mrs), branch, mrs[0].Title)
+	}
+	mr := mrs[0]
 	r.log.Debug("found an open merge request '%s' for branch '%s'", mr.Title, branch)
 	return mr.Title, mr.Description, nil
 }

--- a/internal/gitlab/real_test.go
+++ b/internal/gitlab/real_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestReal_MergeRequestByBranch(t *testing.T) {
 	shell := executor.NewMock()
-	shell.Output = `{"title": "MR Title", "description": "MR Body"}`
+	shell.Output = `[{"title": "MR Title", "description": "MR Body"}]`
 	gl := NewGitlab(shell)
 
 	title, body, err := gl.MergeRequestByBranch("feature-branch")
@@ -18,12 +18,12 @@ func TestReal_MergeRequestByBranch(t *testing.T) {
 	require.NoError(t, err, "MergeRequestByBranch should not return an error")
 	assert.Equal(t, "MR Title", title)
 	assert.Equal(t, "MR Body", body)
-	assert.Contains(t, shell.Commands[0], "glab mr view feature-branch --output json")
+	assert.Contains(t, shell.Commands[0], "glab mr list --source-branch feature-branch --output json")
 }
 
 func TestReal_MergeRequestByBranch_NotFound(t *testing.T) {
 	shell := executor.NewMock()
-	shell.Output = `{}`
+	shell.Output = `[]`
 	gl := NewGitlab(shell)
 
 	title, body, err := gl.MergeRequestByBranch("feature-branch")
@@ -34,6 +34,18 @@ func TestReal_MergeRequestByBranch_NotFound(t *testing.T) {
 	assert.Empty(t, body)
 }
 
+func TestReal_MergeRequestByBranch_Multiple(t *testing.T) {
+	shell := executor.NewMock()
+	shell.Output = `[{"title": "First MR", "description": "First Body"}, {"title": "Second MR", "description": "Second Body"}]`
+	gl := NewGitlab(shell)
+
+	title, body, err := gl.MergeRequestByBranch("feature-branch")
+
+	require.NoError(t, err, "MergeRequestByBranch should not return an error when multiple MRs are found")
+	assert.Equal(t, "First MR", title)
+	assert.Equal(t, "First Body", body)
+}
+
 func TestReal_MergeRequestByBranch_CommandError(t *testing.T) {
 	shell := executor.NewMock()
 	shell.Err = assert.AnError
@@ -42,7 +54,7 @@ func TestReal_MergeRequestByBranch_CommandError(t *testing.T) {
 	title, body, err := gl.MergeRequestByBranch("feature-branch")
 
 	require.Error(t, err, "MergeRequestByBranch should return an error when the command fails")
-	assert.Contains(t, err.Error(), "error fetching merge request for branch 'feature-branch'")
+	assert.Contains(t, err.Error(), "error fetching merge requests for branch 'feature-branch'")
 	assert.Empty(t, title)
 	assert.Empty(t, body)
 }


### PR DESCRIPTION
This PR fixes the `mr --duplicate` command to properly handle branches with multiple merge requests by switching from `glab mr view` to `glab mr list` and gracefully using the first MR when multiple are found.

Fixes #307