### PR TITLE
fix(#312): search all MRs/PRs instead of only open ones

### DIFF
--- a/internal/aidy/real.go
+++ b/internal/aidy/real.go
@@ -355,7 +355,7 @@ func (r *real) PullRequest(fixes bool, target string, duplicate bool, source str
 	nissue := inumber(lookup)
 	var title, body string
 	if duplicate {
-		r.logger.Info("looking up the open pull request for branch '%s' to duplicate...", lookup)
+		r.logger.Info("looking up the pull request for branch '%s' to duplicate...", lookup)
 		title, body, err = r.github.PullRequestByBranch(lookup)
 		if err != nil {
 			return fmt.Errorf("error finding an existing pull request to duplicate: %v", err)
@@ -420,7 +420,7 @@ func (r *real) MergeRequest(fixes bool, target string, duplicate bool, source st
 	nissue := inumber(lookup)
 	var title, body string
 	if duplicate {
-		r.logger.Info("looking up the open merge request for branch '%s' to duplicate...", lookup)
+		r.logger.Info("looking up the merge request for branch '%s' to duplicate...", lookup)
 		title, body, err = r.gitlab.MergeRequestByBranch(lookup)
 		if err != nil {
 			return fmt.Errorf("error finding an existing merge request to duplicate: %v", err)

--- a/internal/aidy/real_test.go
+++ b/internal/aidy/real_test.go
@@ -649,7 +649,7 @@ func TestReal_PullRequest_Duplicate_NoTarget(t *testing.T) {
 
 func TestReal_PullRequest_Duplicate_NotFound(t *testing.T) {
 	github := github.NewMock()
-	github.Error = fmt.Errorf("no open pull request found for branch 'feature'")
+	github.Error = fmt.Errorf("no pull request found for branch 'feature'")
 	out := output.NewMock()
 	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github, editor: out, cache: cache.NewMockAidyCache(), logger: log.Default()}
 
@@ -733,7 +733,7 @@ func TestReal_MergeRequest_Duplicate_NoTarget(t *testing.T) {
 
 func TestReal_MergeRequest_Duplicate_NotFound(t *testing.T) {
 	gl := gitlab.NewMock()
-	gl.Error = fmt.Errorf("no open merge request found for branch 'feature'")
+	gl.Error = fmt.Errorf("no merge request found for branch 'feature'")
 	out := output.NewMock()
 	raidy := &real{git: git.NewMock(), ai: ai.NewMockAI(), github: github.NewMock(), gitlab: gl, editor: out, cache: cache.NewMockAidyCache(), logger: log.Default()}
 

--- a/internal/github/real.go
+++ b/internal/github/real.go
@@ -124,11 +124,11 @@ func (r *github) Labels() ([]string, error) {
 func (r *github) PullRequestByBranch(branch string) (string, string, error) {
 	target := r.ch.Remote()
 	if target == "" {
-		return "", "", fmt.Errorf("cannot find a target repository to search for an open pull request for branch '%s'", branch)
+		return "", "", fmt.Errorf("cannot find a target repository to search for a pull request for branch '%s'", branch)
 	}
 	owner := strings.SplitN(target, "/", 2)[0]
-	url := fmt.Sprintf("%s/repos/%s/pulls?head=%s:%s&state=open", r.url, target, owner, branch)
-	r.log.Debug("trying to find an open pull request using the following url: %s", url)
+	url := fmt.Sprintf("%s/repos/%s/pulls?head=%s:%s&state=all", r.url, target, owner, branch)
+	r.log.Debug("trying to find a pull request using the following url: %s", url)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return "", "", fmt.Errorf("cannot create a new GET request to find a pull request: %w", err)
@@ -155,9 +155,9 @@ func (r *github) PullRequestByBranch(branch string) (string, string, error) {
 		return "", "", fmt.Errorf("error unmarshaling pull requests json: %w", err)
 	}
 	if len(prs) == 0 {
-		return "", "", fmt.Errorf("no open pull request found for branch '%s'", branch)
+		return "", "", fmt.Errorf("no pull request found for branch '%s'", branch)
 	}
-	r.log.Debug("found an open pull request #%d for branch '%s'", prs[0].Number, branch)
+	r.log.Debug("found a pull request #%d for branch '%s'", prs[0].Number, branch)
 	return prs[0].Title, prs[0].Body, nil
 }
 

--- a/internal/github/real_test.go
+++ b/internal/github/real_test.go
@@ -164,7 +164,7 @@ func TestRealGithub_PullRequestByBranch_NotFound(t *testing.T) {
 	title, body, err := gh.PullRequestByBranch("feature-branch")
 
 	require.Error(t, err, "PullRequestByBranch should return an error when no PR is found")
-	assert.Contains(t, err.Error(), "no open pull request found for branch 'feature-branch'")
+	assert.Contains(t, err.Error(), "no pull request found for branch 'feature-branch'")
 	assert.Empty(t, title)
 	assert.Empty(t, body)
 }
@@ -176,7 +176,7 @@ func TestRealGithub_PullRequestByBranch_NoRemote(t *testing.T) {
 	title, body, err := gh.PullRequestByBranch("feature-branch")
 
 	require.Error(t, err, "PullRequestByBranch should return an error when no remote is set")
-	assert.Contains(t, err.Error(), "cannot find a target repository to search for an open pull request for branch 'feature-branch'")
+	assert.Contains(t, err.Error(), "cannot find a target repository to search for a pull request for branch 'feature-branch'")
 	assert.Empty(t, title)
 	assert.Empty(t, body)
 }

--- a/internal/gitlab/real.go
+++ b/internal/gitlab/real.go
@@ -23,7 +23,7 @@ func NewGitlab(shell executor.Executor) *real {
 }
 
 func (r *real) MergeRequestByBranch(branch string) (string, string, error) {
-	out, err := r.shell.RunCommand("glab", "mr", "list", "--source-branch", branch, "--output", "json")
+	out, err := r.shell.RunCommand("glab", "mr", "list", "--source-branch", branch, "--all", "--output", "json")
 	if err != nil {
 		return "", "", fmt.Errorf("error fetching merge requests for branch '%s': %w", branch, err)
 	}
@@ -32,12 +32,12 @@ func (r *real) MergeRequestByBranch(branch string) (string, string, error) {
 		return "", "", fmt.Errorf("error parsing merge request json for branch '%s': %w", branch, err)
 	}
 	if len(mrs) == 0 {
-		return "", "", fmt.Errorf("no open merge request found for branch '%s'", branch)
+		return "", "", fmt.Errorf("no merge request found for branch '%s'", branch)
 	}
 	if len(mrs) > 1 {
-		r.log.Warn("found %d open merge requests for branch '%s', using the first one: '%s'", len(mrs), branch, mrs[0].Title)
+		r.log.Warn("found %d merge requests for branch '%s', using the first one: '%s'", len(mrs), branch, mrs[0].Title)
 	}
 	mr := mrs[0]
-	r.log.Debug("found an open merge request '%s' for branch '%s'", mr.Title, branch)
+	r.log.Debug("found a merge request '%s' for branch '%s'", mr.Title, branch)
 	return mr.Title, mr.Description, nil
 }

--- a/internal/gitlab/real_test.go
+++ b/internal/gitlab/real_test.go
@@ -18,7 +18,7 @@ func TestReal_MergeRequestByBranch(t *testing.T) {
 	require.NoError(t, err, "MergeRequestByBranch should not return an error")
 	assert.Equal(t, "MR Title", title)
 	assert.Equal(t, "MR Body", body)
-	assert.Contains(t, shell.Commands[0], "glab mr list --source-branch feature-branch --output json")
+	assert.Contains(t, shell.Commands[0], "glab mr list --source-branch feature-branch --all --output json")
 }
 
 func TestReal_MergeRequestByBranch_NotFound(t *testing.T) {
@@ -29,7 +29,7 @@ func TestReal_MergeRequestByBranch_NotFound(t *testing.T) {
 	title, body, err := gl.MergeRequestByBranch("feature-branch")
 
 	require.Error(t, err, "MergeRequestByBranch should return an error when no MR is found")
-	assert.Contains(t, err.Error(), "no open merge request found for branch 'feature-branch'")
+	assert.Contains(t, err.Error(), "no merge request found for branch 'feature-branch'")
 	assert.Empty(t, title)
 	assert.Empty(t, body)
 }


### PR DESCRIPTION
Enable `mr --duplicate` and `pr --duplicate` to find closed or merged requests by removing the open-only state filter from GitHub and GitLab API queries, and updating related log messages and error strings accordingly.

Fixes #312