### PR TITLE
feat(#315): add `aidy init` command for interactive config setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,15 @@ You need to have Go 1.24.1 or later installed on your system.
 
 ## Configuration
 
-Create a configuration file in your home directory `~/.aidy.conf.yml` with the following minimal content:
+The quickest way to get started is to run:
+
+```bash
+aidy init
+```
+
+This walks you through choosing an AI provider, a model, and an API key, then writes `~/.aidy.conf.yml` for you. It also asks for a GitHub API key, which you can skip if you don't have one yet. If a configuration file already exists, you'll be asked before it's overwritten.
+
+Alternatively, create the configuration file in your home directory `~/.aidy.conf.yml` yourself with the following minimal content:
 
 ```yaml
 default-model: deepseek

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,151 @@
+package cmd
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/volodya-lombrozo/aidy/internal/config"
+)
+
+var defaultModelIDs = map[string]string{
+	"deepseek":  "deepseek-chat",
+	"openai":    "gpt-4o",
+	"anthropic": "claude-sonnet-4-6",
+}
+
+var providers = []string{"deepseek", "openai", "anthropic"}
+
+func newInitCmd() *cobra.Command {
+	command := &cobra.Command{
+		Use:   "init",
+		Short: "Create a ~/.aidy.conf.yml configuration file",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return fmt.Errorf("error getting home directory: %v", err)
+			}
+			path := filepath.Join(home, ".aidy.conf.yml")
+			return runInit(cmd.InOrStdin(), cmd.OutOrStdout(), path)
+		},
+	}
+	return command
+}
+
+func runInit(in io.Reader, out io.Writer, path string) error {
+	reader := bufio.NewReader(in)
+	if _, err := os.Stat(path); err == nil {
+		overwrite, err := askYesNo(reader, out, fmt.Sprintf("configuration file already exists at '%s', overwrite it?", path))
+		if err != nil {
+			return err
+		}
+		if !overwrite {
+			fmt.Fprintln(out, "aborted, the existing configuration file was left untouched.")
+			return nil
+		}
+	}
+	provider, err := askProvider(reader, out)
+	if err != nil {
+		return err
+	}
+	model, err := ask(reader, out, "model id", defaultModelIDs[provider])
+	if err != nil {
+		return err
+	}
+	key, err := askRequired(reader, out, fmt.Sprintf("%s API key", provider))
+	if err != nil {
+		return err
+	}
+	github, err := ask(reader, out, "GitHub API key (optional, press enter to skip)", "")
+	if err != nil {
+		return err
+	}
+	apiKeys := map[string]string{provider: key}
+	if github != "" {
+		apiKeys["github"] = github
+	}
+	conf := &config.YamlConfig{
+		DefaultModel: provider,
+		APIKeys:      apiKeys,
+		Models: map[string]map[string]string{
+			provider: {
+				"provider": provider,
+				"model-id": model,
+			},
+		},
+	}
+	if err := config.WriteYaml(path, conf); err != nil {
+		return fmt.Errorf("error writing configuration file: %v", err)
+	}
+	fmt.Fprintf(out, "configuration file created at '%s'\n", path)
+	return nil
+}
+
+func askProvider(reader *bufio.Reader, out io.Writer) (string, error) {
+	fmt.Fprintln(out, "choose an AI provider:")
+	for i, p := range providers {
+		fmt.Fprintf(out, "  (%d) %s\n", i+1, p)
+	}
+	for {
+		fmt.Fprint(out, "enter the number of the provider to use: ")
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return "", fmt.Errorf("error reading input: %v", err)
+		}
+		choice := strings.TrimSpace(line)
+		for i, p := range providers {
+			if choice == fmt.Sprintf("%d", i+1) || choice == p {
+				return p, nil
+			}
+		}
+		fmt.Fprintln(out, "invalid choice, please try again.")
+	}
+}
+
+func ask(reader *bufio.Reader, out io.Writer, prompt string, def string) (string, error) {
+	if def != "" {
+		fmt.Fprintf(out, "%s [%s]: ", prompt, def)
+	} else {
+		fmt.Fprintf(out, "%s: ", prompt)
+	}
+	line, err := reader.ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return "", fmt.Errorf("error reading input: %v", err)
+	}
+	answer := strings.TrimSpace(line)
+	if answer == "" {
+		return def, nil
+	}
+	return answer, nil
+}
+
+func askRequired(reader *bufio.Reader, out io.Writer, prompt string) (string, error) {
+	for {
+		answer, err := ask(reader, out, prompt, "")
+		if err != nil {
+			return "", err
+		}
+		if answer != "" {
+			return answer, nil
+		}
+		fmt.Fprintln(out, "this value is required, please try again.")
+	}
+}
+
+func askYesNo(reader *bufio.Reader, out io.Writer, prompt string) (bool, error) {
+	fmt.Fprintf(out, "%s [y/N]: ", prompt)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return false, fmt.Errorf("error reading input: %v", err)
+	}
+	answer := strings.ToLower(strings.TrimSpace(line))
+	return answer == "y" || answer == "yes", nil
+}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -48,8 +48,7 @@ func runInit(in io.Reader, out io.Writer, path string) error {
 			return err
 		}
 		if !overwrite {
-			fmt.Fprintln(out, "aborted, the existing configuration file was left untouched.")
-			return nil
+			return printf(out, "aborted, the existing configuration file was left untouched.\n")
 		}
 	}
 	provider, err := askProvider(reader, out)
@@ -85,17 +84,22 @@ func runInit(in io.Reader, out io.Writer, path string) error {
 	if err := config.WriteYaml(path, conf); err != nil {
 		return fmt.Errorf("error writing configuration file: %v", err)
 	}
-	fmt.Fprintf(out, "configuration file created at '%s'\n", path)
-	return nil
+	return printf(out, "configuration file created at '%s'\n", path)
 }
 
 func askProvider(reader *bufio.Reader, out io.Writer) (string, error) {
-	fmt.Fprintln(out, "choose an AI provider:")
+	if err := printf(out, "choose an AI provider:\n"); err != nil {
+		return "", err
+	}
 	for i, p := range providers {
-		fmt.Fprintf(out, "  (%d) %s\n", i+1, p)
+		if err := printf(out, "  (%d) %s\n", i+1, p); err != nil {
+			return "", err
+		}
 	}
 	for {
-		fmt.Fprint(out, "enter the number of the provider to use: ")
+		if err := printf(out, "enter the number of the provider to use: "); err != nil {
+			return "", err
+		}
 		line, err := reader.ReadString('\n')
 		if err != nil {
 			return "", fmt.Errorf("error reading input: %v", err)
@@ -106,15 +110,21 @@ func askProvider(reader *bufio.Reader, out io.Writer) (string, error) {
 				return p, nil
 			}
 		}
-		fmt.Fprintln(out, "invalid choice, please try again.")
+		if err := printf(out, "invalid choice, please try again.\n"); err != nil {
+			return "", err
+		}
 	}
 }
 
 func ask(reader *bufio.Reader, out io.Writer, prompt string, def string) (string, error) {
+	var err error
 	if def != "" {
-		fmt.Fprintf(out, "%s [%s]: ", prompt, def)
+		err = printf(out, "%s [%s]: ", prompt, def)
 	} else {
-		fmt.Fprintf(out, "%s: ", prompt)
+		err = printf(out, "%s: ", prompt)
+	}
+	if err != nil {
+		return "", err
 	}
 	line, err := reader.ReadString('\n')
 	if err != nil && !errors.Is(err, io.EOF) {
@@ -136,16 +146,25 @@ func askRequired(reader *bufio.Reader, out io.Writer, prompt string) (string, er
 		if answer != "" {
 			return answer, nil
 		}
-		fmt.Fprintln(out, "this value is required, please try again.")
+		if err := printf(out, "this value is required, please try again.\n"); err != nil {
+			return "", err
+		}
 	}
 }
 
 func askYesNo(reader *bufio.Reader, out io.Writer, prompt string) (bool, error) {
-	fmt.Fprintf(out, "%s [y/N]: ", prompt)
+	if err := printf(out, "%s [y/N]: ", prompt); err != nil {
+		return false, err
+	}
 	line, err := reader.ReadString('\n')
 	if err != nil {
 		return false, fmt.Errorf("error reading input: %v", err)
 	}
 	answer := strings.ToLower(strings.TrimSpace(line))
 	return answer == "y" || answer == "yes", nil
+}
+
+func printf(out io.Writer, format string, args ...any) error {
+	_, err := fmt.Fprintf(out, format, args...)
+	return err
 }

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -24,6 +24,23 @@ func TestInit_Help(t *testing.T) {
 	assert.Contains(t, out.String(), "Create a ~/.aidy.conf.yml configuration file")
 }
 
+func TestInit_ExecuteWritesToHomeConfig(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	command := newInitCmd()
+	command.SetIn(strings.NewReader("2\n\nsk-test-openai-key\n"))
+	var out bytes.Buffer
+	command.SetOut(&out)
+
+	err := command.Execute()
+
+	require.NoError(t, err, "no error expected")
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+	conf, err := config.YamlConf(filepath.Join(home, ".aidy.conf.yml"))
+	require.NoError(t, err, "config file should be readable")
+	assert.Equal(t, "openai", conf.DefaultModel)
+}
+
 func TestRunInit_CreatesConfigFileByProviderNumber(t *testing.T) {
 	path := filepath.Join(t.TempDir(), ".aidy.conf.yml")
 	in := strings.NewReader("2\n\nsk-test-openai-key\n")

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,0 +1,157 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/volodya-lombrozo/aidy/internal/config"
+)
+
+func TestInit_Help(t *testing.T) {
+	var out bytes.Buffer
+	command := newInitCmd()
+	command.SetOut(&out)
+	command.SetArgs([]string{"--help"})
+
+	err := command.Execute()
+
+	require.NoError(t, err, "no error expected")
+	assert.Contains(t, out.String(), "Create a ~/.aidy.conf.yml configuration file")
+}
+
+func TestRunInit_CreatesConfigFileByProviderNumber(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".aidy.conf.yml")
+	in := strings.NewReader("2\n\nsk-test-openai-key\n")
+	var out bytes.Buffer
+
+	err := runInit(in, &out, path)
+
+	require.NoError(t, err, "no error expected")
+	assert.Contains(t, out.String(), "configuration file created at")
+	conf, err := config.YamlConf(path)
+	require.NoError(t, err, "config file should be readable")
+	assert.Equal(t, "openai", conf.DefaultModel)
+	provider, err := conf.Provider()
+	require.NoError(t, err)
+	assert.Equal(t, "openai", provider)
+	model, err := conf.Model()
+	require.NoError(t, err)
+	assert.Equal(t, "gpt-4o", model, "should fall back to the default model id")
+	token, err := conf.Token()
+	require.NoError(t, err)
+	assert.Equal(t, "sk-test-openai-key", token)
+}
+
+func TestRunInit_CreatesConfigFileByProviderName(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".aidy.conf.yml")
+	in := strings.NewReader("anthropic\nclaude-sonnet-4-6\nsk-test-anthropic-key\n")
+	var out bytes.Buffer
+
+	err := runInit(in, &out, path)
+
+	require.NoError(t, err, "no error expected")
+	conf, err := config.YamlConf(path)
+	require.NoError(t, err, "config file should be readable")
+	provider, err := conf.Provider()
+	require.NoError(t, err)
+	assert.Equal(t, "anthropic", provider)
+	token, err := conf.Token()
+	require.NoError(t, err)
+	assert.Equal(t, "sk-test-anthropic-key", token)
+}
+
+func TestRunInit_GithubKeyIsOptional(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".aidy.conf.yml")
+	in := strings.NewReader("2\n\nsk-test-openai-key\n")
+	var out bytes.Buffer
+
+	err := runInit(in, &out, path)
+
+	require.NoError(t, err, "no error expected")
+	conf, err := config.YamlConf(path)
+	require.NoError(t, err, "config file should be readable")
+	gh, err := conf.GithubKey()
+	require.NoError(t, err)
+	assert.Empty(t, gh, "github key should be left empty when skipped")
+}
+
+func TestRunInit_GithubKeyIsStoredWhenProvided(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".aidy.conf.yml")
+	in := strings.NewReader("2\n\nsk-test-openai-key\ngh-test-key\n")
+	var out bytes.Buffer
+
+	err := runInit(in, &out, path)
+
+	require.NoError(t, err, "no error expected")
+	conf, err := config.YamlConf(path)
+	require.NoError(t, err, "config file should be readable")
+	gh, err := conf.GithubKey()
+	require.NoError(t, err)
+	assert.Equal(t, "gh-test-key", gh)
+}
+
+func TestRunInit_ReprompsUntilAPIKeyProvided(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".aidy.conf.yml")
+	in := strings.NewReader("1\n\n\nsk-test-deepseek-key\n")
+	var out bytes.Buffer
+
+	err := runInit(in, &out, path)
+
+	require.NoError(t, err, "no error expected")
+	assert.Contains(t, out.String(), "this value is required")
+	conf, err := config.YamlConf(path)
+	require.NoError(t, err, "config file should be readable")
+	token, err := conf.Token()
+	require.NoError(t, err)
+	assert.Equal(t, "sk-test-deepseek-key", token)
+}
+
+func TestRunInit_RepromtsOnInvalidProvider(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".aidy.conf.yml")
+	in := strings.NewReader("nope\n1\n\nsk-test-deepseek-key\n")
+	var out bytes.Buffer
+
+	err := runInit(in, &out, path)
+
+	require.NoError(t, err, "no error expected")
+	assert.Contains(t, out.String(), "invalid choice")
+	conf, err := config.YamlConf(path)
+	require.NoError(t, err, "config file should be readable")
+	provider, err := conf.Provider()
+	require.NoError(t, err)
+	assert.Equal(t, "deepseek", provider)
+}
+
+func TestRunInit_DeclinesOverwrite(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".aidy.conf.yml")
+	require.NoError(t, os.WriteFile(path, []byte("default-model: existing\n"), 0600))
+	in := strings.NewReader("n\n")
+	var out bytes.Buffer
+
+	err := runInit(in, &out, path)
+
+	require.NoError(t, err, "no error expected")
+	assert.Contains(t, out.String(), "aborted")
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "default-model: existing\n", string(data), "existing file should be left untouched")
+}
+
+func TestRunInit_OverwritesOnConfirm(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".aidy.conf.yml")
+	require.NoError(t, os.WriteFile(path, []byte("default-model: existing\n"), 0600))
+	in := strings.NewReader("y\n1\n\nsk-test-deepseek-key\n")
+	var out bytes.Buffer
+
+	err := runInit(in, &out, path)
+
+	require.NoError(t, err, "no error expected")
+	conf, err := config.YamlConf(path)
+	require.NoError(t, err, "config file should be readable")
+	assert.Equal(t, "deepseek", conf.DefaultModel)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,6 +42,7 @@ func NewRootCmd(create func(bool, bool, bool, bool, bool, string) aidy.Aidy) *co
 	root.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "print debug logs")
 	root.PersistentFlags().StringVarP(&language, "language", "l", "en", "language for AI-generated text (e.g. fr, de, ja)")
 	root.AddCommand(
+		newInitCmd(),
 		newCommitCmd(&ctx),
 		newIssueCmd(&ctx),
 		newReleaseCmd(&ctx),

--- a/internal/config/yaml.go
+++ b/internal/config/yaml.go
@@ -25,6 +25,14 @@ func YamlConf(filepath string) (*YamlConfig, error) {
 	return &config, nil
 }
 
+func WriteYaml(filepath string, config *YamlConfig) error {
+	data, err := yaml.Marshal(config)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath, data, 0600)
+}
+
 func (c *YamlConfig) OpenAiKey() (string, error) {
 	return c.APIKeys["openai"], nil
 }

--- a/internal/config/yaml_test.go
+++ b/internal/config/yaml_test.go
@@ -184,6 +184,40 @@ func TestYaml_Token(t *testing.T) {
 	assert.Equal(t, "sk-...", token, "Token should match")
 }
 
+func TestWriteYaml(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "config.yml")
+	original := &YamlConfig{
+		DefaultModel: "openai",
+		APIKeys: map[string]string{
+			"openai": "sk-test",
+			"github": "gh-test",
+		},
+		Models: map[string]map[string]string{
+			"openai": {
+				"provider": "openai",
+				"model-id": "gpt-4o",
+			},
+		},
+	}
+
+	err := WriteYaml(path, original)
+
+	require.NoError(t, err, "no error expected")
+	written, err := YamlConf(path)
+	require.NoError(t, err, "written config should be readable")
+	assert.Equal(t, "openai", written.DefaultModel)
+	assert.Equal(t, "sk-test", written.APIKeys["openai"])
+	assert.Equal(t, "gh-test", written.APIKeys["github"])
+	assert.Equal(t, "gpt-4o", written.Models["openai"]["model-id"])
+}
+
+func TestWriteYaml_FileWriteError(t *testing.T) {
+	err := WriteYaml("/non/existent/dir/config.yml", &YamlConfig{})
+
+	assert.Error(t, err, "Expected an error when the file cannot be written")
+}
+
 func clean(t *testing.T, tmp string) {
 	if err := os.RemoveAll(tmp); err != nil {
 		t.Fatalf("Error removing temp directory: %v", err)


### PR DESCRIPTION
Adds an interactive `aidy init` command that guides users through configuration setup by prompting for AI provider, model, and API keys, then writes the configuration to `~/.aidy.conf.yml`. This eliminates the need for users to manually create the config file.

Fixes #315